### PR TITLE
Use custom subgraph for decoration + SOR

### DIFF
--- a/src/modules/pools/pool.decorator.ts
+++ b/src/modules/pools/pool.decorator.ts
@@ -13,7 +13,7 @@ import {
 } from '@balancer-labs/sdk';
 import debug from 'debug';
 import util from 'util';
-import { getRpcUrl } from '@/modules/network';
+import { getRpcUrl, getSubgraphUrl } from '@/modules/network';
 import { Token, tokensToTokenPrices } from '@/modules/tokens';
 import { PoolService } from './pool.service';
 
@@ -54,6 +54,7 @@ export class PoolDecorator {
     const balancerConfig: BalancerSdkConfig = {
       network: chainId,
       rpcUrl: getRpcUrl(chainId),
+      customSubgraphUrl: getSubgraphUrl(chainId),
     };
     const balancerSdk = new BalancerSDK(balancerConfig);
     const dataRepositories = balancerSdk.data;

--- a/src/modules/sor/sor.ts
+++ b/src/modules/sor/sor.ts
@@ -3,6 +3,7 @@ import { SorRequest, SerializedSwapInfo } from './types';
 import { Token } from '@/modules/tokens';
 import {
   getRpcUrl,
+  getSubgraphUrl,
   getNativeAssetPriceSymbol,
 } from '@/modules/network';
 import { getToken } from '@/modules/dynamodb';
@@ -63,7 +64,8 @@ export async function getSorSwap(
   options: SorSwapOptions = {},
 ): Promise<SerializedSwapInfo> {
   log(`Getting swap: ${JSON.stringify(order)}`);
-  const infuraUrl = getRpcUrl(chainId);
+  const rpcUrl = getRpcUrl(chainId);
+  const subgraphUrl = getSubgraphUrl(chainId);
 
   const useDb = options.useDb ?? true;
   const minLiquidity = options.minLiquidity ?? SOR_MIN_LIQUIDITY;
@@ -86,7 +88,8 @@ export async function getSorSwap(
 
   const balancer = new BalancerSDK({
     network: chainId,
-    rpcUrl: infuraUrl,
+    rpcUrl: rpcUrl,
+    customSubgraphUrl: subgraphUrl,
     sor: sorSettings,
   });
 


### PR DESCRIPTION
Making sure that wherever we use the SDK we use the API's subgraph URL instead of the default one for the SDK. So that if we ever need to change the API subgraph URL (to beta for example) it will be used everywhere. 

- Pass the custom subgraph to decorate function for pool decoration.
- Pass the custom subgraph to SOR. 

