### PR TITLE
Remove aws-cdk as a dependency as it should be installed globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "api-benchmark": "^1.0.1",
-    "aws-cdk": "^2.32.1",
     "esbuild": "*",
     "eslint": "^8.3.0",
     "fishery": "^2.2.2",


### PR DESCRIPTION
AWS recently changed cdk to have cdk-lib which is the libraries you need and aws-cdk which is the package for running deployments etc. This second package should now be installed globally. 

It already mentioned this in the README and was already doing this in the GitHub action. Removing it from package.json should have no effect and will also prevent issues where someone has two copies of CDK installed, one local and one global. 