### PR TITLE
chore: bump SDK to v1.0.1-beta.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "^1.0.1-beta.14",
+        "@balancer-labs/sdk": "^1.0.1-beta.18",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "@sentry/serverless": "^7.29.0",
@@ -660,9 +660,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.0.1-beta.14",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.14.tgz",
-      "integrity": "sha512-l6gASsVctGCwVeBJUDEWZovGvySRi4pfLtazYYSg4jCNoELHCe0viU5eftTGvd37TODPd7Axi/0x+NkVZ+NOUQ==",
+      "version": "1.0.1-beta.18",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.18.tgz",
+      "integrity": "sha512-m3ivDk91lyHBdb5u8YjhrxzvuUbzi7u/hBA3OgZZZi4P1oU8sE+l8fwsFhvaXvNNhXlgLt/+7GKk0ZC9h5zgSQ==",
       "dependencies": {
         "@balancer-labs/sor": "^4.1.1-beta.3",
         "@ethersproject/abi": "^5.4.0",
@@ -11903,9 +11903,9 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.0.1-beta.14",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.14.tgz",
-      "integrity": "sha512-l6gASsVctGCwVeBJUDEWZovGvySRi4pfLtazYYSg4jCNoELHCe0viU5eftTGvd37TODPd7Axi/0x+NkVZ+NOUQ==",
+      "version": "1.0.1-beta.18",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.18.tgz",
+      "integrity": "sha512-m3ivDk91lyHBdb5u8YjhrxzvuUbzi7u/hBA3OgZZZi4P1oU8sE+l8fwsFhvaXvNNhXlgLt/+7GKk0ZC9h5zgSQ==",
       "requires": {
         "@balancer-labs/sor": "^4.1.1-beta.3",
         "@ethersproject/abi": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "^1.0.1-beta.14",
+    "@balancer-labs/sdk": "^1.0.1-beta.18",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "@sentry/serverless": "^7.29.0",


### PR DESCRIPTION
fixing volume / fees on Gnosis Chain