### PR TITLE
Throw error if SOR fails to fetch pools

### DIFF
--- a/src/__mocks__/@balancer-labs/sdk.ts
+++ b/src/__mocks__/@balancer-labs/sdk.ts
@@ -26,7 +26,9 @@ export const mockSwapCostCalculator = {
 export const BalancerSDK = jest.fn().mockImplementation(() => {
   return {
     sor: {
-      fetchPools: jest.fn().mockImplementation(),
+      fetchPools: jest.fn().mockImplementation(() => {
+        return mockSorPools.length > 0;
+      }),
       getSwaps: jest.fn().mockImplementation(() => {
         return mockSwapInfo;
       }),

--- a/src/modules/chain-data/onchain.spec.ts
+++ b/src/modules/chain-data/onchain.spec.ts
@@ -18,6 +18,11 @@ describe('onchain data-provider', () => {
       expect(pools[0].id).toBe(sorPools[0].id);
     });
 
+    it('Should throw an exception if sor fails to fetch pools', async () => {
+      require('@balancer-labs/sdk')._setSorPools([]);
+      expect(async() => { await fetchPoolsFromChain(1); }).rejects.toThrow('SOR Failed to fetch pools');
+    })
+
     it('Should add subgraph information if there is a subgraph pools', async () => {
       const sorPools: SubgraphPoolBase[] = [subgraphPoolBase.build()];
       require('@balancer-labs/sdk')._setSorPools(sorPools);

--- a/src/modules/chain-data/onchain.ts
+++ b/src/modules/chain-data/onchain.ts
@@ -21,7 +21,10 @@ export async function fetchPoolsFromChain(chainId: number): Promise<Pool[]> {
     customSubgraphUrl: subgraphUrl
   });
 
-  await balancer.sor.fetchPools();
+  const fetchedPools: boolean = await balancer.sor.fetchPools();
+  if (!fetchedPools) {
+    throw new Error("SOR Failed to fetch pools");
+  }
   const sorPools: SubgraphPoolBase[] = balancer.sor.getPools();
 
   const subgraphPoolFetcher = new PoolsSubgraphRepository({


### PR DESCRIPTION
SOR started failing to fetch pools today with an error: `Error: fetchPools(): Issue with multicall execution.`. 

However this function doesn't throw the error it just logs it and returns a boolean of false instead. So when this happens throw an Error so we get notified about it with Sentry. 