### PR TITLE
Update subgraph pools that SOR doesn't return

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ curl -X POST -H "Content-Type: application/json" -d '{"sellToken":"0xe91d153e0b4
 
 ## GraphQL Requests
 
-You can run `npx tsx src/scripts/graphql-query.ts` to see example requests fetching pools from the API.
+You can run `npx tsx scripts/graphql-query.ts` to see example requests fetching pools from the API.
 
 ## Options
 

--- a/cdk/appsync/pools/schema.graphql
+++ b/cdk/appsync/pools/schema.graphql
@@ -47,6 +47,7 @@
   apr: AprBreakdown
   maxApr: Int
   isNew: Boolean
+  isInRecoveryMode: Boolean
   protocolYieldFeeCache: String
   priceRateProviders: [PriceRateProvider]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "^1.0.1-beta.19",
+        "@balancer-labs/sdk": "^1.0.1-beta.23",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "@sentry/serverless": "^7.29.0",
@@ -660,9 +660,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.0.1-beta.19",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.19.tgz",
-      "integrity": "sha512-GxsJS7TFF/qRdThouNLwAO6OJZZe/mWvqrCdpLSpSQbetty4D+pFwJVIyyjuUA2kOO2myNDJlVVFbT9SylzG6g==",
+      "version": "1.0.1-beta.23",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.23.tgz",
+      "integrity": "sha512-feXEAoNifYI1A+U7VjFv09dRrvncCQR4ThDDvowFKxzbTFLULiyGGd2TXsynEJJ/EaT+NQ8LXapUXTlpkvDUJA==",
       "dependencies": {
         "@balancer-labs/sor": "^4.1.1-beta.3",
         "@ethersproject/abi": "^5.4.0",
@@ -11903,9 +11903,9 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.0.1-beta.19",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.19.tgz",
-      "integrity": "sha512-GxsJS7TFF/qRdThouNLwAO6OJZZe/mWvqrCdpLSpSQbetty4D+pFwJVIyyjuUA2kOO2myNDJlVVFbT9SylzG6g==",
+      "version": "1.0.1-beta.23",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.23.tgz",
+      "integrity": "sha512-feXEAoNifYI1A+U7VjFv09dRrvncCQR4ThDDvowFKxzbTFLULiyGGd2TXsynEJJ/EaT+NQ8LXapUXTlpkvDUJA==",
       "requires": {
         "@balancer-labs/sor": "^4.1.1-beta.3",
         "@ethersproject/abi": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "^1.0.1-beta.19",
+    "@balancer-labs/sdk": "^1.0.1-beta.23",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "@sentry/serverless": "^7.29.0",

--- a/scripts/graphql-query.ts
+++ b/scripts/graphql-query.ts
@@ -41,7 +41,7 @@ const complexQuery = `query {
         contains: []
       }, 
       poolType: {
-        not_in: ["Element", "AaveLinear", "Linear", "ERC4626Linear", "FX"]
+        in: ["Weighted", "Stable", "MetaStable", "LiquidityBootstrapping", "Investment", "StablePhantom", "ComposableStable"]
       }, 
       totalShares: {
         gt: 0.01

--- a/src/modules/chain-data/onchain.spec.ts
+++ b/src/modules/chain-data/onchain.spec.ts
@@ -36,6 +36,21 @@ describe('onchain data-provider', () => {
       expect(pools[0].poolType).toBe(PoolType.Weighted);
     });
 
+    it('Should return pools from the subgraph that arent returned by SOR', async () => {
+      const sorPools: SubgraphPoolBase[] = [subgraphPoolBase.build()];
+      require('@balancer-labs/sdk')._setSorPools(sorPools);
+      const subgraphPools: Pool[] = [
+        poolBase.build({
+          id: '0x133d241f225750d2c92948e464a5a80111920331000000000000000000000476'
+        }),
+      ];
+      require('@balancer-labs/sdk')._setSubgraphPools(subgraphPools);
+      const pools = await fetchPoolsFromChain(1);
+      expect(pools.length).toBe(2);
+      expect(pools[0].id).toBe(sorPools[0].id);
+      expect(pools[1].id).toBe(subgraphPools[0].id);
+    });
+
     it('Should over-write token priceRates with subgraph data', async () => {
       const newPriceRate = "1.15";
       const sorPools: SubgraphPoolBase[] = [subgraphPoolBase.build()];

--- a/src/modules/dynamodb/dynamodb-marshaller.ts
+++ b/src/modules/dynamodb/dynamodb-marshaller.ts
@@ -101,7 +101,7 @@ function finalizeUnmarshalledItem(schema: Schema, item) {
  * but numbers in DynamoDB.
  * e.g. totalLiquidity: '123.456' -> totalLiquidity: {'N': '123.456'}
  */
-export function marshallPool(pool: Pool): Record<string, any> {
+export function marshallPool(pool: Partial<Pool>): Record<string, any> {
   const autoMarshaller = new Marshaller();
   const autoMarshalledPool = autoMarshaller.marshallItem(pool);
 
@@ -149,7 +149,7 @@ export function discardStaticFields(
 }
 
 export function generateUpdateExpression(
-  pool: Pool,
+  pool: Partial<Pool>,
   options?: UpdatePoolOptions
 ): UpdateExpression {
   const primaryKeyAttributes = ['id', 'chainId'];

--- a/src/modules/dynamodb/dynamodb.ts
+++ b/src/modules/dynamodb/dynamodb.ts
@@ -53,7 +53,7 @@ export async function isAlive() {
   return true;
 }
 
-export async function updatePools(pools: Pool[], options?: UpdatePoolOptions) {
+export async function updatePools(pools: Partial<Pool>[], options?: UpdatePoolOptions) {
   const dynamodb = getDynamoDB();
 
   const allPoolUpdateRequests = pools.map(function (pool) {

--- a/src/modules/pools/utils.ts
+++ b/src/modules/pools/utils.ts
@@ -111,7 +111,7 @@ export function isSame(newPool: Partial<Pool>, oldPool?: Pool): boolean {
 }
 
 
-export function getTokenAddressesFromPools(pools: Pool[]): string[] {
+export function getTokenAddressesFromPools(pools: Partial<Pool>[]): string[] {
   const tokenAddressMap = {};
   pools.forEach(pool => {
     pool.tokensList.forEach(address => {

--- a/src/modules/pools/utils.ts
+++ b/src/modules/pools/utils.ts
@@ -47,7 +47,7 @@ export function isValidApr(apr: AprBreakdown) {
  * of all pools that have changed in newPools
  */
 
-export function getChangedPools(newPools: Pool[], currentPools: Pool[]) {
+export function getChangedPools(newPools: Partial<Pool>[], currentPools: Pool[]) {
   const currentPoolsMap = Object.fromEntries(
     currentPools.map(pool => {
       return [pool.id, pool];
@@ -74,7 +74,7 @@ export function isSchemaFieldANumber(key: string, schema: Schema): boolean {
   return numberTypes.includes(schema[key]?.type)
 }
 
-export function isSame(newPool: Pool, oldPool?: Pool): boolean {
+export function isSame(newPool: Partial<Pool>, oldPool?: Pool): boolean {
   if (!oldPool) return false;
 
   const poolFieldsToCompare = getNonStaticSchemaFields(POOL_SCHEMA);

--- a/tests/factories/pools.ts
+++ b/tests/factories/pools.ts
@@ -8,6 +8,7 @@ import { namedTokens } from './named-tokens';
 
 export type PoolParams = {
   type: PoolType;
+  id?: string;
 }
 
 type LinearTokens = {
@@ -101,7 +102,7 @@ const poolBase = Factory.define<Pool, PoolParams>(
     ];
 
     return {
-      id: '0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e',
+      id: params.id || '0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e',
       address: '0xa6f548df93de924d73be7d25dc02554c6bd66db5',
       name: 'Default Pool',
       chainId: 1,


### PR DESCRIPTION
- SOR doesn't fetch some pools because of bad on-chain data. Pools that are skipped should instead be updated from the subgraph only.
- This also adds more types to this class and fixes issues where types weren't being adhered to correctly. 

Tested in dev account and it is updating Euler pool values correctly. 