### PR TITLE
chore: bump SDK to v1.0.3-beta.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "v1.0.1-beta.29",
+        "@balancer-labs/sdk": "v1.0.3-beta.4",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "@sentry/serverless": "^7.29.0",
@@ -660,9 +660,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.0.1-beta.29",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.29.tgz",
-      "integrity": "sha512-LSUz2vXfbRYBu2MtLcdRKUNhgS7geFlrmXYrciumHrlOxGz+cKe4sZBpUpI2X2mF39e5PVes3MDtUW90R1xbfA==",
+      "version": "1.0.3-beta.4",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.3-beta.4.tgz",
+      "integrity": "sha512-2r+vLuuSgkNA9+Abtd9i3aMmu1dnU/thwPP9EuPuj99EXoWOkWU6Y8sf92LlipLRTVyPHMEij8TmQiEzfp1sDQ==",
       "dependencies": {
         "@balancer-labs/sor": "^4.1.1-beta.6",
         "@ethersproject/abi": "^5.4.0",
@@ -11903,9 +11903,9 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.0.1-beta.29",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.1-beta.29.tgz",
-      "integrity": "sha512-LSUz2vXfbRYBu2MtLcdRKUNhgS7geFlrmXYrciumHrlOxGz+cKe4sZBpUpI2X2mF39e5PVes3MDtUW90R1xbfA==",
+      "version": "1.0.3-beta.4",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.3-beta.4.tgz",
+      "integrity": "sha512-2r+vLuuSgkNA9+Abtd9i3aMmu1dnU/thwPP9EuPuj99EXoWOkWU6Y8sf92LlipLRTVyPHMEij8TmQiEzfp1sDQ==",
       "requires": {
         "@balancer-labs/sor": "^4.1.1-beta.6",
         "@ethersproject/abi": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "v1.0.1-beta.29",
+    "@balancer-labs/sdk": "v1.0.3-beta.4",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "@sentry/serverless": "^7.29.0",

--- a/src/modules/pools/pool.service.ts
+++ b/src/modules/pools/pool.service.ts
@@ -22,7 +22,9 @@ export class PoolService {
     networkConfig: BalancerNetworkConfig,
     repositories: BalancerDataRepositories
   ) {
-    this.pools = new Pools(networkConfig, repositories);
+    // Passing in an empty object for the contracts as we don't need it for this service
+    // it's only needed for the PoolFactories which is part of the creation service
+    this.pools = new Pools(networkConfig, repositories, {} as any);
   }
 
   /**


### PR DESCRIPTION
Changes the way we fetch external tokens APRs. Instead of including clients in the SDK all tokens are processed in the proxy function hosted on Cloudflare.