### PR TITLE
fix: sdk token yields repository issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "v1.0.3-beta.4",
+        "@balancer-labs/sdk": "v1.0.3-beta.7",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "@sentry/serverless": "^7.29.0",
@@ -660,11 +660,11 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.0.3-beta.4",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.3-beta.4.tgz",
-      "integrity": "sha512-2r+vLuuSgkNA9+Abtd9i3aMmu1dnU/thwPP9EuPuj99EXoWOkWU6Y8sf92LlipLRTVyPHMEij8TmQiEzfp1sDQ==",
+      "version": "1.0.3-beta.7",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.3-beta.7.tgz",
+      "integrity": "sha512-7wWJnX/IQTb111z4FMIvFqlA3FoUlcr4p5Xxj+1AXLLwgNybMrSl8tBBx501MpXXIJKBUDEmxcYlKP6J0lrN9w==",
       "dependencies": {
-        "@balancer-labs/sor": "^4.1.1-beta.6",
+        "@balancer-labs/sor": "^4.1.1-beta.7",
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/address": "^5.4.0",
@@ -700,9 +700,9 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "4.1.1-beta.6",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.6.tgz",
-      "integrity": "sha512-Bfeqa2XZJowjSqLr0bv6ndKY4FOIR+upOWt0ILSzNNd2MLXiklWklg6TeAvTZXknOC+1zDCyiPUjEH+YfvA2Zw==",
+      "version": "4.1.1-beta.7",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.7.tgz",
+      "integrity": "sha512-pb/IVYVeQXCvOZ06qoVJ2KGUTHeL4go9Je7Z5VSTYg26SYx8PNWEKeF9bdg/mo8TOweu4upcLj78PTNBLPF/fQ==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1"
       },
@@ -11903,11 +11903,11 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.0.3-beta.4",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.3-beta.4.tgz",
-      "integrity": "sha512-2r+vLuuSgkNA9+Abtd9i3aMmu1dnU/thwPP9EuPuj99EXoWOkWU6Y8sf92LlipLRTVyPHMEij8TmQiEzfp1sDQ==",
+      "version": "1.0.3-beta.7",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.3-beta.7.tgz",
+      "integrity": "sha512-7wWJnX/IQTb111z4FMIvFqlA3FoUlcr4p5Xxj+1AXLLwgNybMrSl8tBBx501MpXXIJKBUDEmxcYlKP6J0lrN9w==",
       "requires": {
-        "@balancer-labs/sor": "^4.1.1-beta.6",
+        "@balancer-labs/sor": "^4.1.1-beta.7",
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/address": "^5.4.0",
@@ -11935,9 +11935,9 @@
       }
     },
     "@balancer-labs/sor": {
-      "version": "4.1.1-beta.6",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.6.tgz",
-      "integrity": "sha512-Bfeqa2XZJowjSqLr0bv6ndKY4FOIR+upOWt0ILSzNNd2MLXiklWklg6TeAvTZXknOC+1zDCyiPUjEH+YfvA2Zw==",
+      "version": "4.1.1-beta.7",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.7.tgz",
+      "integrity": "sha512-pb/IVYVeQXCvOZ06qoVJ2KGUTHeL4go9Je7Z5VSTYg26SYx8PNWEKeF9bdg/mo8TOweu4upcLj78PTNBLPF/fQ==",
       "requires": {
         "isomorphic-fetch": "^2.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "v1.0.3-beta.4",
+    "@balancer-labs/sdk": "v1.0.3-beta.7",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "@sentry/serverless": "^7.29.0",

--- a/src/modules/chain-data/onchain.ts
+++ b/src/modules/chain-data/onchain.ts
@@ -55,8 +55,8 @@ export async function fetchPoolsFromChain(chainId: number): Promise<Partial<Pool
     subgraphPools = subgraphPools.concat(poolBatch);
   } while (poolBatch.length > 0);
 
-  const sorPoolsMap = Object.fromEntries(sorPools.map(pool => [pool.id, pool]));
-  const subgraphPoolsMap = Object.fromEntries(
+  const sorPoolsMap: Record<string, SubgraphPoolBase> = Object.fromEntries(sorPools.map(pool => [pool.id, pool]));
+  const subgraphPoolsMap: Record<string, SDKPool> = Object.fromEntries(
     subgraphPools.map(pool => [pool.id, pool])
   );
 

--- a/src/modules/chain-data/onchain.ts
+++ b/src/modules/chain-data/onchain.ts
@@ -69,7 +69,7 @@ export async function fetchPoolsFromChain(chainId: number): Promise<Partial<Pool
         poolType: sorPool.poolType as PoolType,
         chainId,
       }
-    );
+    ) as Partial<Pool>;
   });
 
   const subgraphPoolsMissingFromSor: Partial<Pool>[] = subgraphPools

--- a/src/modules/sor/pool-data-service.ts
+++ b/src/modules/sor/pool-data-service.ts
@@ -1,5 +1,6 @@
 import debug from 'debug';
-import { PoolDataService, SubgraphPoolBase } from '@balancer-labs/sdk';
+import { PoolDataService } from '@balancer-labs/sor';
+import { SubgraphPoolBase } from '@balancer-labs/sdk';
 import { getPools, queryPools } from '@/modules/dynamodb';
 import { Pool, convertPoolToSubgraphPoolBase } from '@/modules/pools';
 


### PR DESCRIPTION
Hotfix for the merged token yields repository. Issue was that repo was fetching the same source multiple times before the fetch promise resolved. Updated to hit the source URL only once.

I've seen two ts issues as well. Added some syntax to make the build pass. Not sure how safe is this one:

https://github.com/balancer/balancer-api/blob/feat/sdk-update/src/modules/chain-data/onchain.ts#L72