### PR TITLE
Add isPaused to schema

### DIFF
--- a/cdk/appsync/pools/schema.graphql
+++ b/cdk/appsync/pools/schema.graphql
@@ -48,6 +48,7 @@
   maxApr: Int
   isNew: Boolean
   isInRecoveryMode: Boolean
+  isPaused: Boolean
   protocolYieldFeeCache: String
   priceRateProviders: [PriceRateProvider]
 }


### PR DESCRIPTION
Requires https://github.com/balancer/balancer-sdk/pull/417 to be merged and SDK version to be updated first. 

Tested by building SDK and manually copying files and it works correctly and isPaused is being set on pools correctly. 