### PR TITLE
Update SDK to 1.0.6-beta.2 for Gyro + FX pool support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "^1.0.5-beta.10",
+        "@balancer-labs/sdk": "^1.0.6-beta.0",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "@sentry/serverless": "^7.29.0",
@@ -660,11 +660,11 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.0.5-beta.10",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.5-beta.10.tgz",
-      "integrity": "sha512-T+4OH8q5DbFgWt+km1bxExaAJcGGK/PjReqHpilWqCVYKD4kU1YzovZljQ6tlbzgPihZz4+T/8Efne4W0Y0B/g==",
+      "version": "1.0.6-beta.0",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.6-beta.0.tgz",
+      "integrity": "sha512-fcG9csDCbH2lRq3lJuQ1c5/B8qxVC8E7zaAdBEXEKHWgRLlhHMOtD1C4KaOSTeBR5WCISoJTbi3vKvGs9+eBrg==",
       "dependencies": {
-        "@balancer-labs/sor": "^4.1.1-beta.8",
+        "@balancer-labs/sor": "^4.1.1-beta.9",
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/address": "^5.4.0",
@@ -700,9 +700,9 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "4.1.1-beta.8",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.8.tgz",
-      "integrity": "sha512-By0k3apw/8MLu7UJAsV1xj3kxp9WON8cZI3REFKfOl4xvJq+yB1qR7BHbtR0p7bYZSwUucdiPMevSAlcAXNAsA==",
+      "version": "4.1.1-beta.9",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.9.tgz",
+      "integrity": "sha512-jwqEkjOgc9qTnuQGne/ZnG+ynx4ca4qEIgRClJVH2tCCf+pXL7jVPWv/v3I+7dJs2aCyet4uIsXwU/vi2jK+/Q==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1"
       },
@@ -11903,11 +11903,11 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.0.5-beta.10",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.5-beta.10.tgz",
-      "integrity": "sha512-T+4OH8q5DbFgWt+km1bxExaAJcGGK/PjReqHpilWqCVYKD4kU1YzovZljQ6tlbzgPihZz4+T/8Efne4W0Y0B/g==",
+      "version": "1.0.6-beta.0",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.6-beta.0.tgz",
+      "integrity": "sha512-fcG9csDCbH2lRq3lJuQ1c5/B8qxVC8E7zaAdBEXEKHWgRLlhHMOtD1C4KaOSTeBR5WCISoJTbi3vKvGs9+eBrg==",
       "requires": {
-        "@balancer-labs/sor": "^4.1.1-beta.8",
+        "@balancer-labs/sor": "^4.1.1-beta.9",
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
         "@ethersproject/address": "^5.4.0",
@@ -11935,9 +11935,9 @@
       }
     },
     "@balancer-labs/sor": {
-      "version": "4.1.1-beta.8",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.8.tgz",
-      "integrity": "sha512-By0k3apw/8MLu7UJAsV1xj3kxp9WON8cZI3REFKfOl4xvJq+yB1qR7BHbtR0p7bYZSwUucdiPMevSAlcAXNAsA==",
+      "version": "4.1.1-beta.9",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.1.1-beta.9.tgz",
+      "integrity": "sha512-jwqEkjOgc9qTnuQGne/ZnG+ynx4ca4qEIgRClJVH2tCCf+pXL7jVPWv/v3I+7dJs2aCyet4uIsXwU/vi2jK+/Q==",
       "requires": {
         "isomorphic-fetch": "^2.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "^1.0.6-beta.0",
+        "@balancer-labs/sdk": "^1.0.6-beta.2",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "@sentry/serverless": "^7.29.0",
@@ -660,9 +660,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.0.6-beta.0",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.6-beta.0.tgz",
-      "integrity": "sha512-fcG9csDCbH2lRq3lJuQ1c5/B8qxVC8E7zaAdBEXEKHWgRLlhHMOtD1C4KaOSTeBR5WCISoJTbi3vKvGs9+eBrg==",
+      "version": "1.0.6-beta.2",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.6-beta.2.tgz",
+      "integrity": "sha512-CWQ8DQPwCL0u0RZgeq0WhH2msHdte6L4Xy88jM2ma1gtJ/M6namrlOlBJTBoYph0S237yQXt/rw4puNCLR4ZKg==",
       "dependencies": {
         "@balancer-labs/sor": "^4.1.1-beta.9",
         "@ethersproject/abi": "^5.4.0",
@@ -11903,9 +11903,9 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.0.6-beta.0",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.6-beta.0.tgz",
-      "integrity": "sha512-fcG9csDCbH2lRq3lJuQ1c5/B8qxVC8E7zaAdBEXEKHWgRLlhHMOtD1C4KaOSTeBR5WCISoJTbi3vKvGs9+eBrg==",
+      "version": "1.0.6-beta.2",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.6-beta.2.tgz",
+      "integrity": "sha512-CWQ8DQPwCL0u0RZgeq0WhH2msHdte6L4Xy88jM2ma1gtJ/M6namrlOlBJTBoYph0S237yQXt/rw4puNCLR4ZKg==",
       "requires": {
         "@balancer-labs/sor": "^4.1.1-beta.9",
         "@ethersproject/abi": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "^1.0.6-beta.0",
+    "@balancer-labs/sdk": "^1.0.6-beta.2",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "@sentry/serverless": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "^1.0.5-beta.10",
+    "@balancer-labs/sdk": "^1.0.6-beta.0",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "@sentry/serverless": "^7.29.0",

--- a/src/modules/pools/pool.decorator.ts
+++ b/src/modules/pools/pool.decorator.ts
@@ -19,8 +19,8 @@ import { PoolService } from './pool.service';
 
 const log = debug('balancer:pool-decorator');
 
-const UNKNOWN_POOL_TYPES = ['GyroE', 'FX', 'HighAmpComposableStable'];
-const IGNORED_POOL_TYPES = [...UNKNOWN_POOL_TYPES, PoolType.Element, PoolType.Gyro2, PoolType.Gyro3];
+const UNKNOWN_POOL_TYPES = ['HighAmpComposableStable'];
+const IGNORED_POOL_TYPES = [...UNKNOWN_POOL_TYPES, PoolType.Element];
 
 export interface PoolDecoratorOptions {
   chainId?: number;


### PR DESCRIPTION
Adds Gyro and FX Pool APR / Liquidity calculations to the API. Tested in dev and appears to be working correctly

Gyro pools to test with on Polygon:

```
GyroE
0x97469e6236bd467cd147065f77752b00efadce8a0002000000000000000008c0
0x3f6110b9322bc1633d5f63ccdfdf5dd648588b8a0002000000000000000008e3
0xa489c057de6c3177380ea264ebdf686b7f564f510002000000000000000008e2
0xf0ad209e2e969eaaa8c882aac71f02d8a047d5c2000200000000000000000b49

Gyro2
0xfa9ee04a5545d8e0a26b30f5ca5cbecd75ea645f000200000000000000000798
0x08b83439aeaccbcfb172a7327af38832fb9b7af400020000000000000000077b
0xc35864c1fb71d4f620e3e808a78fe2005af1efa7000200000000000000000797
0xae2a061c9f7a0486febfce17bcfb19dd777dd23c0002000000000000000006dc
0xdac42eeb17758daa38caf9a3540c808247527ae3000200000000000000000a2b
0x7ec3e47ca85602351ee252c0bfae14e1e2c90bd500020000000000000000077f
0xf16a66320fafe03c9bf6daaaebe9418f17620de60002000000000000000008e1
0x6313449d06ad99a7baca0ddb7e0b5f9f2048cf86000200000000000000000772

Gyro3
0x88856e26914a4503fb9669e159aae96d3f3cb66b0001000000000000000006e9
0x17f1ef81707811ea15d9ee7c741179bbe2a63887000100000000000000000799
0x66f6db795a93ce1ca5dc5daba74aead98da8e06a0001000000000000000006fa
0xb211043347cb9f2dfd8b981996820e2886b0ef1800010000000000000000077e
0x1a076c59321a38bf48431081e8fe3420de67de8f000100000000000000000771
```

FX Pools to test with on Polygon:

```
0x726e324c29a1e49309672b244bdc4ff62a270407000200000000000000000702
```
