### PR TITLE
Add poolTypeVersion to schema

### DIFF
--- a/cdk/appsync/pools/schema.graphql
+++ b/cdk/appsync/pools/schema.graphql
@@ -18,6 +18,7 @@
   id: String!
   address: String
   poolType: String
+  poolTypeVersion: Int
   factory: String
   symbol: String
   name: String


### PR DESCRIPTION
This is needed by the frontend. It's already in the database, just not in the graphQL schema. 