### PR TITLE
Add Lambda to Allowlist Pools

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,7 @@ jobs:
         TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
         TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
         SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        GH_WEBHOOK_PAT: ${{ secrets.GH_WEBHOOK_PAT }}
         DOMAIN_NAME: 'api.balancer.fi'
         NETWORKS: '1,100,137,1101,42161,43114'
         DYNAMODB_POOLS_READ_CAPACITY: 200

--- a/src/__mocks__/@ethersproject/contracts.ts
+++ b/src/__mocks__/@ethersproject/contracts.ts
@@ -6,10 +6,21 @@ let decimalsMethod = jest.fn().mockImplementation(() => {
   return Promise.resolve(2);
 });
 
+let versionMethod = jest.fn().mockImplementation(() => {
+  return Promise.resolve(
+    JSON.stringify({
+      name: 'ComposableStablePool',
+      version: 3,
+      deployment: '20230206-composable-stable-pool-v3',
+    })
+  );
+});
+
 export function Contract() {
   return {
     symbol: symbolMethod,
     decimals: decimalsMethod,
+    version: versionMethod,
   };
 }
 
@@ -19,4 +30,8 @@ export function _setSymbolMethod(method) {
 
 export function _setDecimalsMethod(method) {
   decimalsMethod = method;
+}
+
+export function _setVersionMethod(method) {
+  versionMethod = method;
 }

--- a/src/config/arbitrum.json
+++ b/src/config/arbitrum.json
@@ -1,5 +1,6 @@
 {
   "networkId": 42161,
+  "network": "arbitrum",
   "rpc": "https://arbitrum-mainnet.infura.io/v3/{{INFURA_PROJECT_ID}}",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2-beta",
   "addresses": {

--- a/src/config/avalanche.json
+++ b/src/config/avalanche.json
@@ -1,5 +1,6 @@
 {
   "networkId": 43114,
+  "network": "avalanche",
   "rpc": "https://avalanche-mainnet.infura.io/v3/{{INFURA_PROJECT_ID}}",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-avalanche-v2",
   "addresses": {

--- a/src/config/gnosis-chain.json
+++ b/src/config/gnosis-chain.json
@@ -1,5 +1,6 @@
 {
   "networkId": 100,
+  "network": "gnosis-chain",
   "rpc": "https://poa-xdai.gateway.pokt.network/v1/lb/91bc0e12a76e7a84dd76189d",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gnosis-chain-v2",
   "addresses": {

--- a/src/config/goerli.json
+++ b/src/config/goerli.json
@@ -1,5 +1,6 @@
 {
   "networkId": 5,
+  "network": "goerli",
   "rpc": "https://goerli.infura.io/v3/{{INFURA_KEY}}",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-goerli-v2",
   "addresses": {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,6 +9,7 @@ import zkevm from './zkevm.json';
 
 export interface Config {
   networkId: number;
+  network: string;
   rpc: string;
   subgraph: string;
   addresses: {

--- a/src/config/mainnet.json
+++ b/src/config/mainnet.json
@@ -1,5 +1,6 @@
 {
   "networkId": 1,
+  "network": "mainnet",
   "rpc": "https://mainnet.infura.io/v3/{{INFURA_PROJECT_ID}}",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2",
   "addresses": {

--- a/src/config/polygon.json
+++ b/src/config/polygon.json
@@ -1,5 +1,6 @@
 {
   "networkId": 137,
+  "network": "polygon",
   "rpc": "https://polygon-mainnet.infura.io/v3/{{INFURA_PROJECT_ID}}",
   "subgraph": "https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2",
   "addresses": {

--- a/src/config/zkevm.json
+++ b/src/config/zkevm.json
@@ -1,5 +1,6 @@
 {
   "networkId": 1101,
+  "network": "zkevm",
   "rpc": "https://polygonzkevm-mainnet.g.alchemy.com/v2/{{ALCHEMY_KEY}}",
   "subgraph": "https://api.studio.thegraph.com/query/24660/balancer-polygon-zkevm-v2/v0.0.2",
   "addresses": {

--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -15,6 +15,10 @@ export const WEEK_IN_MS = DAY_IN_MS * 7;
 
 export const MAX_VALID_TO_EPOCH = 2 ** 32 - 1;
 
+export const ALLOWLIST_POOL_ENDPOINT =
+  'https://api.github.com/repos/timjrobinson/frontend-v2/dispatches';
+
+
 export const Network: Record<string, number> = {
   MAINNET: 1,
   GOERLI: 5,

--- a/src/lambdas/hal-webhook.spec.ts
+++ b/src/lambdas/hal-webhook.spec.ts
@@ -1,0 +1,102 @@
+import nock from 'nock';
+import { handler } from './check-wallet';
+import { TRMAccountDetails } from '@/modules/trm';
+
+nock.disableNetConnect();
+
+let trmResponse: TRMAccountDetails[] = [];
+
+const request = {
+  queryStringParameters: {
+    address: '0x0000000000000000000000000000000000000000',
+  },
+};
+
+describe('Wallet Check Lambda', () => {
+  it('Should return false for an address with no issues', async () => {
+    trmResponse = [
+      {
+        accountExternalId: null,
+        address: '0x0000000000000000000000000000000000000000',
+        addressRiskIndicators: [],
+        addressSubmitted: '0x0000000000000000000000000000000000000000',
+        chain: 'ethereum',
+        entities: [],
+        trmAppUrl:
+          'https://my.trmlabs.com/address/0x0000000000000000000000000000000000000000/eth',
+      },
+    ];
+    nock('https://api.trmlabs.com')
+      .post('/public/v2/screening/addresses')
+      .reply(200, trmResponse);
+    const response = await handler(request);
+    const body = JSON.parse(response.body);
+    expect(body.is_blocked).toBe(false);
+  });
+
+  it('Should return blocked for an address that has a Severe risk', async () => {
+    trmResponse = [
+      {
+        accountExternalId: null,
+        address: '0x0000000000000000000000000000000000000000',
+        addressRiskIndicators: [
+          {
+            category: 'Sanctions',
+            categoryId: '69',
+            categoryRiskScoreLevel: 15,
+            categoryRiskScoreLevelLabel: 'Severe',
+            incomingVolumeUsd:
+              '570037717.3324722239717737602882028941260267337',
+            outgoingVolumeUsd:
+              '573357789.82550046115536928143858188991303929335',
+            riskType: 'OWNERSHIP',
+            totalVolumeUsd: '1143395507.15797268512714304172678478403906602705',
+          },
+          {
+            category: 'Sanctions',
+            categoryId: '69',
+            categoryRiskScoreLevel: 15,
+            categoryRiskScoreLevelLabel: 'Severe',
+            incomingVolumeUsd: '0',
+            outgoingVolumeUsd:
+              '428172699.46703217102356766551565669942647220227',
+            riskType: 'COUNTERPARTY',
+            totalVolumeUsd: '428172699.46703217102356766551565669942647220227',
+          },
+        ],
+        addressSubmitted: '0x0000000000000000000000000000000000000000',
+        chain: 'ethereum',
+        entities: [
+          {
+            category: 'Sanctions',
+            categoryId: '69',
+            entity: 'Lazarus Group',
+            riskScoreLevel: 15,
+            riskScoreLevelLabel: 'Severe',
+            trmAppUrl:
+              'https://my.trmlabs.com/entities/trm/75624c42-157e-4a63-8f32-070b1d1fa4d4',
+            trmUrn: '/entity/manual/75624c42-157e-4a63-8f32-070b1d1fa4d4',
+          },
+          {
+            category: 'Hacked or Stolen Funds',
+            categoryId: '34',
+            entity: 'Ronin Bridge Hack - March 2022',
+            riskScoreLevel: 15,
+            riskScoreLevelLabel: 'Severe',
+            trmAppUrl:
+              'https://my.trmlabs.com/entities/trm/9145c0ff-1544-475f-8403-40840cb051e0',
+            trmUrn: '/entity/manual/9145c0ff-1544-475f-8403-40840cb051e0',
+          },
+        ],
+        trmAppUrl:
+          'https://my.trmlabs.com/address/0x0000000000000000000000000000000000000000/eth',
+      },
+    ];
+    nock('https://api.trmlabs.com')
+      .post('/public/v2/screening/addresses')
+      .reply(200, trmResponse);
+    const response = await handler(request);
+    const body = JSON.parse(response.body);
+    expect(body.is_blocked).toBe(true);
+  });
+});

--- a/src/lambdas/hal-webhook.ts
+++ b/src/lambdas/hal-webhook.ts
@@ -9,11 +9,11 @@ import {
 import { isValidNetworkId } from '@/modules/network';
 import { allowlistPool } from '@/modules/allowlist';
 
-
-/** This webhook takes events from hal.xyz and performs actions with them
- * 
- * The first action is to listen to new pool creation events on the Balancer Vault 
- * and send the event details 
+/**
+ * This webhook takes events from hal.xyz and performs actions with them
+ *
+ * The first action is to listen to new pool creation events on the Balancer Vault
+ * and send the event details to a Github Webhook that creates a PR to allowlist the pool
  */
 
 export const handler = wrapHandler(async (event: any = {}): Promise<any> => {
@@ -38,17 +38,13 @@ export const handler = wrapHandler(async (event: any = {}): Promise<any> => {
       const parameters = event.eventParameters;
       if (event.eventName === HALEventName.TokensRegistered) {
         const poolId = parameters.poolId;
-        await allowlistPool(chainId, "Weighted", poolId);
+        await allowlistPool(chainId, poolId);
         console.log(`Successfully allowlisted pool ${poolId}`);
       }
-    })
-
-
+    });
   } catch (e) {
-    console.log(
-      `Received error processing HAL Webhook: ${e}`
-    );
-    captureException(e)
+    console.log(`Received error processing HAL Webhook: ${e}`);
+    captureException(e);
     return formatResponse(500, 'Unable to process webhook event');
   }
 });

--- a/src/modules/allowlist/index.ts
+++ b/src/modules/allowlist/index.ts
@@ -1,0 +1,1 @@
+export * from './pool';

--- a/src/modules/allowlist/pool.spec.ts
+++ b/src/modules/allowlist/pool.spec.ts
@@ -1,0 +1,48 @@
+import nock from 'nock';
+import { allowlistPool } from './pool';
+import { callGitHubWebhook } from '@/modules/github';
+
+nock.disableNetConnect();
+
+jest.mock('@ethersproject/contracts');
+jest.mock(
+  '@/modules/github',
+  jest.fn().mockImplementation(() => {
+    return {
+      callGitHubWebhook: jest.fn().mockImplementation(() => {
+        return { status: 200 };
+      }),
+    };
+  })
+);
+
+describe('Allowlist Pool', () => {
+  it('Should call the Github webhook with data passed into function', async () => {
+    require('@ethersproject/contracts')._setSymbolMethod(() =>
+      Promise.resolve('bb-a-USD')
+    );
+    require('@ethersproject/contracts')._setVersionMethod(() =>
+      Promise.resolve(
+        JSON.stringify({
+          name: 'ComposableStablePool',
+          version: 3,
+          deployment: '20230206-composable-stable-pool-v3',
+        })
+      )
+    );
+    await allowlistPool(
+      1,
+      '0xfebb0bbf162e64fb9d0dfe186e517d84c395f016000000000000000000000502'
+    );
+    expect(callGitHubWebhook).toBeCalledWith({
+      event_type: 'allowlist_pool',
+      client_payload: {
+        network: "mainnet",
+        poolType: 'Stable',
+        poolId:
+          '0xfebb0bbf162e64fb9d0dfe186e517d84c395f016000000000000000000000502',
+        poolDescription: 'bb-a-USD',
+      },
+    });
+  });
+});

--- a/src/modules/allowlist/pool.spec.ts
+++ b/src/modules/allowlist/pool.spec.ts
@@ -1,6 +1,7 @@
 import nock from 'nock';
 import { allowlistPool } from './pool';
 import { callGitHubWebhook } from '@/modules/github';
+import { ALLOWLIST_POOL_ENDPOINT } from '@/constants';
 
 nock.disableNetConnect();
 
@@ -34,7 +35,7 @@ describe('Allowlist Pool', () => {
       1,
       '0xfebb0bbf162e64fb9d0dfe186e517d84c395f016000000000000000000000502'
     );
-    expect(callGitHubWebhook).toBeCalledWith({
+    expect(callGitHubWebhook).toBeCalledWith(ALLOWLIST_POOL_ENDPOINT, {
       event_type: 'allowlist_pool',
       client_payload: {
         network: "mainnet",

--- a/src/modules/allowlist/pool.ts
+++ b/src/modules/allowlist/pool.ts
@@ -1,0 +1,32 @@
+import configs  from '@/config';
+import fetch from 'isomorphic-fetch';
+
+const { GITHUB_PAT } = process.env;
+
+const ALLOWLIST_POOL_ENDPOINT =
+  'https://api.github.com/repos/timjrobinson/frontend-v2/dispatches';
+
+export async function allowlistPool(
+  chainId: number,
+  poolType: string,
+  poolId: string,
+  poolDescription = ''
+) {
+  const network = configs[chainId].network;
+
+  return fetch(ALLOWLIST_POOL_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `token ${GITHUB_PAT}`
+    },
+    body: JSON.stringify({
+      event_type: 'allowlist_pool',
+      client_payload: {
+        network,
+        poolType,
+        poolId,
+        poolDescription
+      }
+    })
+  });
+}

--- a/src/modules/allowlist/pool.ts
+++ b/src/modules/allowlist/pool.ts
@@ -4,11 +4,9 @@ import { getRpcUrl } from '@/modules/network';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { convertPoolIdToAddress } from '@/modules/pools';
 import { Contract } from '@ethersproject/contracts';
+import { ALLOWLIST_POOL_ENDPOINT } from '@/constants';
 
 const { GH_WEBHOOK_PAT } = process.env;
-
-const ALLOWLIST_POOL_ENDPOINT =
-  'https://api.github.com/repos/timjrobinson/frontend-v2/dispatches';
 
 export async function allowlistPool(chainId: number, poolId: string) {
   console.log(`Allowlisting pool ${poolId}`);

--- a/src/modules/allowlist/pool.ts
+++ b/src/modules/allowlist/pool.ts
@@ -4,6 +4,7 @@ import { JsonRpcProvider } from '@ethersproject/providers';
 import { convertPoolIdToAddress } from '@/modules/pools';
 import { Contract } from '@ethersproject/contracts';
 import { callGitHubWebhook } from '@/modules/github';
+import { ALLOWLIST_POOL_ENDPOINT } from '@/constants';
 
 
 export async function allowlistPool(chainId: number, poolId: string) {
@@ -56,7 +57,7 @@ export async function allowlistPool(chainId: number, poolId: string) {
 
   const network = configs[chainId].network;
 
-  const response = await callGitHubWebhook({
+  const response = await callGitHubWebhook(ALLOWLIST_POOL_ENDPOINT, {
     event_type: 'allowlist_pool',
     client_payload: {
       network,

--- a/src/modules/allowlist/pool.ts
+++ b/src/modules/allowlist/pool.ts
@@ -1,12 +1,10 @@
 import configs from '@/config';
-import fetch from 'isomorphic-fetch';
 import { getRpcUrl } from '@/modules/network';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { convertPoolIdToAddress } from '@/modules/pools';
 import { Contract } from '@ethersproject/contracts';
-import { ALLOWLIST_POOL_ENDPOINT } from '@/constants';
+import { callGitHubWebhook } from '@/modules/github';
 
-const { GH_WEBHOOK_PAT } = process.env;
 
 export async function allowlistPool(chainId: number, poolId: string) {
   console.log(`Allowlisting pool ${poolId}`);
@@ -58,20 +56,14 @@ export async function allowlistPool(chainId: number, poolId: string) {
 
   const network = configs[chainId].network;
 
-  const response = await fetch(ALLOWLIST_POOL_ENDPOINT, {
-    method: 'POST',
-    headers: {
-      Authorization: `token ${GH_WEBHOOK_PAT}`,
+  const response = await callGitHubWebhook({
+    event_type: 'allowlist_pool',
+    client_payload: {
+      network,
+      poolType,
+      poolId,
+      poolDescription,
     },
-    body: JSON.stringify({
-      event_type: 'allowlist_pool',
-      client_payload: {
-        network,
-        poolType,
-        poolId,
-        poolDescription,
-      },
-    }),
   });
 
   console.log('Got response from Github: ', response);
@@ -80,3 +72,4 @@ export async function allowlistPool(chainId: number, poolId: string) {
     throw new Error('Failed to send allowlist request to Github');
   }
 }
+

--- a/src/modules/github/index.ts
+++ b/src/modules/github/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './webhook';

--- a/src/modules/github/types.ts
+++ b/src/modules/github/types.ts
@@ -1,0 +1,4 @@
+export interface GitHubWebhookParams {
+  event_type: string;
+  client_payload: Record<string, string>;
+}

--- a/src/modules/github/webhook.ts
+++ b/src/modules/github/webhook.ts
@@ -1,11 +1,10 @@
 import fetch from 'isomorphic-fetch';
 import { GitHubWebhookParams } from "./types";
-import { ALLOWLIST_POOL_ENDPOINT } from '@/constants';
 
 const { GH_WEBHOOK_PAT } = process.env;
 
-export async function callGitHubWebhook(body: GitHubWebhookParams): Promise<ReturnType<fetch>> {
-  return await fetch(ALLOWLIST_POOL_ENDPOINT, {
+export async function callGitHubWebhook(endpoint: string, body: GitHubWebhookParams): Promise<ReturnType<fetch>> {
+  return await fetch(endpoint, {
     method: 'POST',
     headers: {
       Authorization: `token ${GH_WEBHOOK_PAT}`,

--- a/src/modules/github/webhook.ts
+++ b/src/modules/github/webhook.ts
@@ -1,0 +1,15 @@
+import fetch from 'isomorphic-fetch';
+import { GitHubWebhookParams } from "./types";
+import { ALLOWLIST_POOL_ENDPOINT } from '@/constants';
+
+const { GH_WEBHOOK_PAT } = process.env;
+
+export async function callGitHubWebhook(body: GitHubWebhookParams): Promise<ReturnType<fetch>> {
+  return await fetch(ALLOWLIST_POOL_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `token ${GH_WEBHOOK_PAT}`,
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/src/modules/hal/index.ts
+++ b/src/modules/hal/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/modules/hal/types.ts
+++ b/src/modules/hal/types.ts
@@ -7,14 +7,8 @@ export enum HALEventName {
 export interface HALEvent {
   contractAddress: Address;
   eventName: HALEventName;
-  eventParameters: HALEventParameters
+  eventParameters: any;
   transaction: HALTransaction;
-}
-
-export interface HALEventParameters {
-  assetManagers: Address[];
-  poolId: string;
-  tokens: Address[];
 }
 
 export interface HALTransaction {
@@ -26,4 +20,12 @@ export interface HALTransaction {
   hash: string;
   value: string | null;
   inputData: string;
+}
+
+export interface TokenRegisteredEvent extends HALEvent {
+  eventParameters: {
+    assetManagers: Address[];
+    poolId: string;
+    tokens: Address[];
+  }
 }

--- a/src/modules/hal/types.ts
+++ b/src/modules/hal/types.ts
@@ -1,0 +1,29 @@
+type Address = string;
+
+export enum HALEventName {
+  TokensRegistered = 'TokensRegistered'
+}
+
+export interface HALEvent {
+  contractAddress: Address;
+  eventName: HALEventName;
+  eventParameters: HALEventParameters
+  transaction: HALTransaction;
+}
+
+export interface HALEventParameters {
+  assetManagers: Address[];
+  poolId: string;
+  tokens: Address[];
+}
+
+export interface HALTransaction {
+  blockHash: string;
+  blockNumber: number;
+  blockTimestamp: number;
+  from: Address;
+  to: Address;
+  hash: string;
+  value: string | null;
+  inputData: string;
+}

--- a/src/modules/pools/utils.ts
+++ b/src/modules/pools/utils.ts
@@ -120,3 +120,7 @@ export function getTokenAddressesFromPools(pools: Partial<Pool>[]): string[] {
   });
   return Object.keys(tokenAddressMap);
 }
+
+export function convertPoolIdToAddress(poolId: string) {
+  return poolId.substring(0, 42);
+}


### PR DESCRIPTION
This lambda receives new pool events from hal.xyz, extracts information about the pool such as it's type and symbol, and sends an Allowlist request to the frontend Github Webhook so that we have automatically created PR's for each new pool users create rather than having to wait for users to send them to us. 