### PR TITLE
Feat- Sepolia Support

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,9 +2,10 @@ import { Network } from '@/constants';
 import arbitrum from './arbitrum.json';
 import avalanche from './avalanche.json';
 import goerli from './goerli.json';
+import gnosis from './gnosis-chain.json';
 import mainnet from './mainnet.json';
 import polygon from './polygon.json';
-import gnosis from './gnosis-chain.json';
+import sepolia from './sepolia.json';
 import zkevm from './zkevm.json';
 
 export interface Config {
@@ -32,7 +33,8 @@ const config: Record<number, Config> = {
   [Network.ARBITRUM]: arbitrum,
   [Network.GNOSIS]: gnosis,
   [Network.ZKEVM]: zkevm,
-  [Network.AVALANCHE]: avalanche
+  [Network.AVALANCHE]: avalanche,
+  [Network.SEPOLIA]: sepolia,
 };
 
 export default config;

--- a/src/config/sepolia.json
+++ b/src/config/sepolia.json
@@ -1,0 +1,17 @@
+{
+  "networkId": 11155111,
+  "network": "sepolia",
+  "rpc": "https://sepolia.infura.io/v3/{{INFURA_KEY}}",
+  "subgraph": "https://api.studio.thegraph.com/query/24660/balancer-sepolia-v2/version/latest",
+  "addresses": {
+    "nativeAsset": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+    "wrappedNativeAsset": "0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9",
+    "vault": "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
+    "batchRelayer": "0x6d5342d716c13d9a3F072a2B11498624ADe27f90"
+  },
+  "coingecko": {
+    "platformId": "ethereum",
+    "nativeAssetId": "ethereum",
+    "nativeAssetPriceSymbol": "eth"
+  }
+}

--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -29,7 +29,8 @@ export const Network: Record<string, number> = {
   GNOSIS: 100,
   ZKEVM: 1101,
   ARBITRUM: 42161,
-  AVALANCHE: 43114
+  AVALANCHE: 43114,
+  SEPOLIA: 11155111,
 };
 
 export const TEST_NETWORKS: Record<string, number> = Object.fromEntries(


### PR DESCRIPTION
Adds Sepolia config to the API. Not really used currently (we don't load test network tokens in the API currently), but could be in the future. 