### PR TITLE
Send network as 'ethereum' to pools webhook as it has changed

### DIFF
--- a/src/modules/allowlist/pool.spec.ts
+++ b/src/modules/allowlist/pool.spec.ts
@@ -40,7 +40,7 @@ describe('Allowlist Pool', () => {
     expect(callGitHubWebhook).toBeCalledWith(ALLOWLIST_POOL_ENDPOINT, {
       event_type: 'allowlist_pool',
       client_payload: {
-        network: "mainnet",
+        network: "ethereum",
         poolType: 'Stable',
         poolId:
           '0xfebb0bbf162e64fb9d0dfe186e517d84c395f016000000000000000000000502',

--- a/src/modules/allowlist/pool.ts
+++ b/src/modules/allowlist/pool.ts
@@ -24,7 +24,11 @@ export async function allowlistPool(chainId: number, poolId: string) {
 
   console.log(`pool type: ${poolType}`);
 
-  const network = configs[chainId].network;
+  let network = configs[chainId].network;
+  if (network === 'mainnet') {
+    network = 'ethereum';
+  }
+
   const webhookData = {
     event_type: 'allowlist_pool',
     client_payload: {


### PR DESCRIPTION
Changed in: https://github.com/balancer/frontend-v2/pull/3930
