### PR TITLE
Add defender webhook

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -132,22 +132,22 @@ export class BalancerPoolsAPI extends Stack {
       writeCapacity: POOLS_WRITE_CAPACITY,
     });
 
-    const poolsTableReadScaling = poolsTable.autoScaleReadCapacity({ 
+    const poolsTableReadScaling = poolsTable.autoScaleReadCapacity({
       minCapacity: POOLS_READ_CAPACITY,
-      maxCapacity: POOLS_READ_CAPACITY * AUTOSCALE_MAX_MULTIPLIER
+      maxCapacity: POOLS_READ_CAPACITY * AUTOSCALE_MAX_MULTIPLIER,
     });
 
     poolsTableReadScaling.scaleOnUtilization({
-      targetUtilizationPercent: 80
+      targetUtilizationPercent: 80,
     });
 
-    const poolsTableWriteScaling = poolsTable.autoScaleWriteCapacity({ 
+    const poolsTableWriteScaling = poolsTable.autoScaleWriteCapacity({
       minCapacity: POOLS_WRITE_CAPACITY,
-      maxCapacity: POOLS_WRITE_CAPACITY * AUTOSCALE_MAX_MULTIPLIER
+      maxCapacity: POOLS_WRITE_CAPACITY * AUTOSCALE_MAX_MULTIPLIER,
     });
 
     poolsTableWriteScaling.scaleOnUtilization({
-      targetUtilizationPercent: 80
+      targetUtilizationPercent: 80,
     });
 
     poolsTable.addGlobalSecondaryIndex({
@@ -198,17 +198,22 @@ export class BalancerPoolsAPI extends Stack {
     const secondaryIndexCapacities: Capacities = {
       read: {
         min: POOLS_IDX_READ_CAPACITY,
-        max: POOLS_IDX_READ_CAPACITY * AUTOSCALE_MAX_MULTIPLIER
+        max: POOLS_IDX_READ_CAPACITY * AUTOSCALE_MAX_MULTIPLIER,
       },
       write: {
         min: POOLS_IDX_WRITE_CAPACITY,
-        max: POOLS_IDX_WRITE_CAPACITY * AUTOSCALE_MAX_MULTIPLIER
-      }
-    }
+        max: POOLS_IDX_WRITE_CAPACITY * AUTOSCALE_MAX_MULTIPLIER,
+      },
+    };
 
-    autoScaleSecondaryIndex(this, 'byTotalLiquidity', secondaryIndexCapacities, 80)
-    autoScaleSecondaryIndex(this, 'byVolume', secondaryIndexCapacities, 80)
-    autoScaleSecondaryIndex(this, 'byApr', secondaryIndexCapacities, 80)
+    autoScaleSecondaryIndex(
+      this,
+      'byTotalLiquidity',
+      secondaryIndexCapacities,
+      80
+    );
+    autoScaleSecondaryIndex(this, 'byVolume', secondaryIndexCapacities, 80);
+    autoScaleSecondaryIndex(this, 'byApr', secondaryIndexCapacities, 80);
 
     const tokensTable = new Table(this, 'tokens', {
       partitionKey: {
@@ -225,22 +230,22 @@ export class BalancerPoolsAPI extends Stack {
       writeCapacity: TOKENS_WRITE_CAPACITY,
     });
 
-    const tokensTableReadScaling = tokensTable.autoScaleReadCapacity({ 
+    const tokensTableReadScaling = tokensTable.autoScaleReadCapacity({
       minCapacity: TOKENS_READ_CAPACITY,
-      maxCapacity: TOKENS_READ_CAPACITY * AUTOSCALE_MAX_MULTIPLIER
+      maxCapacity: TOKENS_READ_CAPACITY * AUTOSCALE_MAX_MULTIPLIER,
     });
 
     tokensTableReadScaling.scaleOnUtilization({
-      targetUtilizationPercent: 80
+      targetUtilizationPercent: 80,
     });
 
-    const tokensTableWriteScaling = tokensTable.autoScaleWriteCapacity({ 
+    const tokensTableWriteScaling = tokensTable.autoScaleWriteCapacity({
       minCapacity: TOKENS_WRITE_CAPACITY,
-      maxCapacity: TOKENS_WRITE_CAPACITY * AUTOSCALE_MAX_MULTIPLIER
+      maxCapacity: TOKENS_WRITE_CAPACITY * AUTOSCALE_MAX_MULTIPLIER,
     });
 
     tokensTableWriteScaling.scaleOnUtilization({
-      targetUtilizationPercent: 80
+      targetUtilizationPercent: 80,
     });
 
     /**
@@ -386,17 +391,21 @@ export class BalancerPoolsAPI extends Stack {
       timeout: Duration.seconds(15),
     });
 
-    const defenderWebhookLambda = new NodejsFunction(this, 'defenderWebhookFunction', {
-      entry: join(__dirname, 'src', 'lambdas', 'defender-webhook.ts'),
-      environment: {
-        ...nodeJsFunctionProps.environment,
-        GH_WEBHOOK_PAT: GH_WEBHOOK_PAT || '',
-        ALLOWLIST_POOL_ENDPOINT: ALLOWLIST_POOL_ENDPOINT || '',
-        ALLOWLIST_TOKEN_ENDPOINT: ALLOWLIST_TOKEN_ENDPOINT || '',
-      },
-      runtime: Runtime.NODEJS_14_X,
-      timeout: Duration.seconds(15),
-    });
+    const defenderWebhookLambda = new NodejsFunction(
+      this,
+      'defenderWebhookFunction',
+      {
+        entry: join(__dirname, 'src', 'lambdas', 'defender-webhook.ts'),
+        environment: {
+          ...nodeJsFunctionProps.environment,
+          GH_WEBHOOK_PAT: GH_WEBHOOK_PAT || '',
+          ALLOWLIST_POOL_ENDPOINT: ALLOWLIST_POOL_ENDPOINT || '',
+          ALLOWLIST_TOKEN_ENDPOINT: ALLOWLIST_TOKEN_ENDPOINT || '',
+        },
+        runtime: Runtime.NODEJS_14_X,
+        timeout: Duration.seconds(15),
+      }
+    );
 
     /**
      * Lambda Schedules
@@ -409,26 +418,38 @@ export class BalancerPoolsAPI extends Stack {
       new LambdaFunction(updateTokenPricesLambda)
     );
 
-
     const updatePeriodWord = UPDATE_POOLS_INTERVAL > 1 ? 'minutes' : 'minute';
-    Object.entries(updatePoolsLambdas).forEach(([chainId, updatePoolsLambda]) => {
-      const updatePoolsRule = new Rule(this, `updatePoolsInterval-${chainId}`, {
-        schedule: Schedule.expression(
-          `rate(${UPDATE_POOLS_INTERVAL} ${updatePeriodWord})`
-        ),
-      });
-      updatePoolsRule.addTarget(new LambdaFunction(updatePoolsLambda));
-    });
+    Object.entries(updatePoolsLambdas).forEach(
+      ([chainId, updatePoolsLambda]) => {
+        const updatePoolsRule = new Rule(
+          this,
+          `updatePoolsInterval-${chainId}`,
+          {
+            schedule: Schedule.expression(
+              `rate(${UPDATE_POOLS_INTERVAL} ${updatePeriodWord})`
+            ),
+          }
+        );
+        updatePoolsRule.addTarget(new LambdaFunction(updatePoolsLambda));
+      }
+    );
 
-    const decoratePeriodWord = DECORATE_POOLS_INTERVAL > 1 ? 'minutes' : 'minute';
-    Object.entries(decoratePoolsLambdas).forEach(([chainId, decoratePoolsLambda]) => {
-      const decoratePoolsRule = new Rule(this, `decoratePoolsInterval-${chainId}`, {
-        schedule: Schedule.expression(
-          `rate(${DECORATE_POOLS_INTERVAL} ${decoratePeriodWord})`
-        ),
-      });
-      decoratePoolsRule.addTarget(new LambdaFunction(decoratePoolsLambda));
-    });
+    const decoratePeriodWord =
+      DECORATE_POOLS_INTERVAL > 1 ? 'minutes' : 'minute';
+    Object.entries(decoratePoolsLambdas).forEach(
+      ([chainId, decoratePoolsLambda]) => {
+        const decoratePoolsRule = new Rule(
+          this,
+          `decoratePoolsInterval-${chainId}`,
+          {
+            schedule: Schedule.expression(
+              `rate(${DECORATE_POOLS_INTERVAL} ${decoratePeriodWord})`
+            ),
+          }
+        );
+        decoratePoolsRule.addTarget(new LambdaFunction(decoratePoolsLambda));
+      }
+    );
 
     /**
      * Access Rules
@@ -494,7 +515,7 @@ export class BalancerPoolsAPI extends Stack {
         'integration.request.path.chainId': 'method.request.path.chainId',
         'integration.request.querystring.useDb':
           'method.request.querystring.useDb',
-          'integration.request.querystring.minLiquidity':
+        'integration.request.querystring.minLiquidity':
           'method.request.querystring.minLiquidity',
       },
     });
@@ -529,12 +550,9 @@ export class BalancerPoolsAPI extends Stack {
         'integration.request.path.chainId': 'method.request.path.chainId',
       },
     });
-    const defenderWebhookIntegration = new LambdaIntegration(defenderWebhookLambda, {
-      proxy: true,
-      requestParameters: {
-        'integration.request.path.chainId': 'method.request.path.chainId',
-      },
-    });
+    const defenderWebhookIntegration = new LambdaIntegration(
+      defenderWebhookLambda
+    );
 
     const apiGatewayLogGroup = new LogGroup(this, 'ApiGatewayLogs');
 
@@ -639,7 +657,7 @@ export class BalancerPoolsAPI extends Stack {
       },
     });
     addCorsOptions(order);
-  
+
     const checkWallet = api.root.addResource('check-wallet');
     checkWallet.addMethod('GET', checkWalletIntegration, {
       requestParameters: {
@@ -667,12 +685,7 @@ export class BalancerPoolsAPI extends Stack {
     });
 
     const defender = api.root.addResource('defender');
-    const defenderOnChain = defender.addResource('{chainId}');
-    defenderOnChain.addMethod('POST', defenderWebhookIntegration, {
-      requestParameters: {
-        'method.request.path.chainId': true,
-      },
-    });
+    defender.addMethod('POST', defenderWebhookIntegration);
 
     /**
      * Web Application Firewall

--- a/src/lambdas/defender-webhook.spec.ts
+++ b/src/lambdas/defender-webhook.spec.ts
@@ -1,0 +1,76 @@
+import { handler } from './defender-webhook';
+import { DefenderBody } from '@/modules/defender';
+import { allowlistPool, allowlistTokens } from '@/modules/allowlist';
+import mockDefenderEventBodyEthereum from '../../tests/mocks/defender-event-body-ethereum'
+import mockDefenderEventBodyArbitrum from '../../tests/mocks/defender-event-body-arbitrum'
+
+jest.mock(
+  '@/modules/allowlist',
+  jest.fn().mockImplementation(() => {
+    return {
+      allowlistPool: jest.fn().mockImplementation(),
+      allowlistTokens: jest.fn().mockImplementation()
+    }
+  })
+);
+
+let request;
+
+describe('Defender Webhook Lambda', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  })
+  describe('TokenRegisteredEvent Ethereum', () => {
+    beforeEach(() => {
+      const body: DefenderBody = mockDefenderEventBodyEthereum;
+
+      request = {
+        body
+      }
+    });
+
+    it('Should call allowlistPool with the chainId and poolId from the data', async () => {
+      const response = await handler(request);
+      expect(response.statusCode).toBe(200);
+      expect(allowlistPool).toBeCalledWith(1, '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb60002000000000000000005d7');
+    });
+
+    it('Should call allowlistToken with the chainId and tokens from the data', async () => {
+      const response = await handler(request);
+      expect(response.statusCode).toBe(200);
+      expect(allowlistTokens).toBeCalledWith(1, [
+        '0x8929e9DbD2785e3BA16175E596CDD61520feE0D1',
+        '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      ]);
+    });
+
+  });
+
+  describe('TokenRegisteredEvent Arbitrum', () => {
+    beforeEach(() => {
+      const body: DefenderBody = mockDefenderEventBodyArbitrum;
+
+      request = {
+        body
+      }
+    });
+
+    it('Should call allowlistPool with the chainId and poolId from the data', async () => {
+      const response = await handler(request);
+      expect(response.statusCode).toBe(200);
+      expect(allowlistPool).toBeCalledWith(42161, '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd00000000000000000000049e');
+    });
+
+    it('Should call allowlistToken with the chainId and tokens from the data', async () => {
+      const response = await handler(request);
+      expect(response.statusCode).toBe(200);
+      expect(allowlistTokens).toBeCalledWith(42161, [
+        '0x0c8972437a38b389ec83d1E666b69b8a4fcf8bfd',
+        '0x5979D7b546E38E414F7E9822514be443A4800529',
+        '0x95aB45875cFFdba1E5f451B950bC2E42c0053f39',
+        '0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8',
+      ]);
+    });
+
+  });
+});

--- a/src/lambdas/defender-webhook.ts
+++ b/src/lambdas/defender-webhook.ts
@@ -1,0 +1,46 @@
+import { wrapHandler } from '@/modules/sentry';
+import { captureException } from '@sentry/serverless';
+import { formatResponse } from './utils';
+import {
+  INVALID_CHAIN_ID_ERROR,
+  MISSING_CHAIN_ID_ERROR,
+} from '@/constants/errors';
+import { isValidNetworkId } from '@/modules/network';
+// import { allowlistPool, allowlistTokens } from '@/modules/allowlist';
+// import debug from 'debug';
+
+/**
+ * This webhook takes events from hal.xyz and performs actions with them
+ *
+ * The first action is to listen to new pool creation events on the Balancer Vault
+ * and send the event details to a Github Webhook that creates a PR to allowlist the pool
+ */
+
+const log = console.log;
+
+export const handler = wrapHandler(async (event: any = {}): Promise<any> => {
+  log("Processing event: ", event);
+
+  const chainId = parseInt(event.pathParameters.chainId);
+  if (!chainId) {
+    return MISSING_CHAIN_ID_ERROR;
+  }
+  if (!isValidNetworkId(chainId)) {
+    return INVALID_CHAIN_ID_ERROR;
+  }
+
+  if (!event.body) {
+    return {
+      statusCode: 400,
+      body: 'invalid request, you are missing the parameter body',
+    };
+  }
+
+  try {
+    return { statusCode: 200 };
+  } catch (e) {
+    console.log(`Received error processing HAL Webhook: ${e}`);
+    captureException(e);
+    return formatResponse(500, 'Unable to process webhook event');
+  }
+});

--- a/src/lambdas/defender-webhook.ts
+++ b/src/lambdas/defender-webhook.ts
@@ -6,7 +6,7 @@ import { allowlistPool, allowlistTokens } from '@/modules/allowlist';
 import debug from 'debug';
 
 /**
- * This webhook takes events from hal.xyz and performs actions with them
+ * This webhook takes events from OpenZeppelin Defender and performs actions with them
  *
  * The first action is to listen to new pool creation events on the Balancer Vault
  * and send the event details to a Github Webhook that creates a PR to allowlist the pool

--- a/src/modules/allowlist/pool.spec.ts
+++ b/src/modules/allowlist/pool.spec.ts
@@ -20,6 +20,10 @@ jest.mock(
 );
 
 describe('Allowlist Pool', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  })
+
   it('Should call the Github webhook with data passed into function', async () => {
     require('@ethersproject/contracts')._setSymbolMethod(() =>
       Promise.resolve('bb-a-USD')
@@ -47,5 +51,17 @@ describe('Allowlist Pool', () => {
         poolDescription: 'bb-a-USD',
       },
     });
+  });
+
+  it('Should be avoided for LBP pools', async () => {
+    require('@ethersproject/contracts')._setSymbolMethod(() =>
+      Promise.resolve('SUPER_DUMMY_LBP')
+    );
+
+    await allowlistPool(
+      1,
+      '0xfebb0bbf162e64fb9d0dfe186e517d84c395f016000000000000000000000502'
+    );
+    expect(callGitHubWebhook).not.toBeCalled();
   });
 });

--- a/src/modules/allowlist/pool.ts
+++ b/src/modules/allowlist/pool.ts
@@ -13,6 +13,9 @@ export async function allowlistPool(chainId: number, poolId: string) {
 
   const poolDescription = await getPoolSymbolFromContract(poolId, provider);
 
+  // Ignore LPB pools as they do not require allowlisting
+  if (poolDescription.endsWith('_LBP')) return
+
   let poolType = getPoolTypeFromId(poolId);
   if (!poolType) {
     poolType = await getPoolTypeFromContract(poolId, provider);

--- a/src/modules/defender/index.ts
+++ b/src/modules/defender/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/modules/defender/types.ts
+++ b/src/modules/defender/types.ts
@@ -1,0 +1,77 @@
+
+
+export interface DefenderBody {
+  events: DefenderEvent[]
+}
+
+
+export interface DefenderEvent {
+  hash: string;
+  transaction: Transaction;
+  blockHash: string;
+  blockNumber: string;
+  timestamp: number;
+  matchReasons: MatchReason[];
+  matchedAddresses: any[];
+  matchedChecksumAddresses: any[];
+  sentinel: Sentinel;
+  type: string;
+  value: string;
+}
+
+export interface Transaction {
+  blockHash: string;
+  blockNumber: string;
+  contractAddress: string | null;
+  cumulativeGasUsed: string;
+  effectiveGasPrice: string;
+  from: string;
+  gasUsed: string;
+  gasUsedForL1?: string;
+  l1BlockNumber?: string;
+  logs: TransactionLog[];
+  logsBloom: string;
+  status: string;
+  to: string;
+  transactionHash: string;
+  transactionIndex: string;
+  type: string;
+}
+
+export interface MatchReason {
+  type: string;
+  signature: string;
+  address: string;
+  args: any[];
+  params: any;
+}
+
+export interface TokensRegisteredMatchReason extends MatchReason {
+  params: {
+    poolId: string;
+    tokens: string[];
+    assetManagers: string[]
+  }
+}
+
+export interface TransactionLog {
+  address: string;
+  topics: string[];
+  data: string;
+  blockNumber: string;
+  transactionHash: string;
+  transactionIndex: string;
+  blockHash: string;
+  logIndex: string;
+  removed: boolean;
+}
+
+export interface Sentinel {
+  id: string;
+  name: string;
+  abi: any;
+  addresses: string[];
+  confirmBlocks: number;
+  network: string;
+  chainId: number;
+}

--- a/src/modules/pools/utils.ts
+++ b/src/modules/pools/utils.ts
@@ -143,7 +143,7 @@ export function getPoolTypeFromId(poolId: string): PoolType | undefined {
   }
 }
 
-export async function getPoolSymbolFromContract(poolId: string, provider: JsonRpcProvider): Promise<PoolType | undefined> {
+export async function getPoolSymbolFromContract(poolId: string, provider: JsonRpcProvider): Promise<string | undefined> {
   const poolAddress = convertPoolIdToAddress(poolId);
 
   const poolDetailsContract = new Contract(
@@ -162,7 +162,6 @@ export async function getPoolSymbolFromContract(poolId: string, provider: JsonRp
     );
   }
 
- 
 }
 
 export async function getPoolTypeFromContract(poolId: string, provider: JsonRpcProvider): Promise<PoolType | undefined> {

--- a/tests/mocks/defender-event-body-arbitrum.ts
+++ b/tests/mocks/defender-event-body-arbitrum.ts
@@ -1,0 +1,1255 @@
+import { DefenderBody } from '@/modules/defender';
+
+const defenderEventBody: DefenderBody = {
+  events: [
+    {
+      hash: '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+      transaction: {
+        blockHash:
+          '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+        blockNumber: '0x76478aa',
+        contractAddress: null,
+        cumulativeGasUsed: '0x65682c',
+        effectiveGasPrice: '0x5f5e100',
+        from: '0x854b004700885a61107b458f11ecc169a019b764',
+        gasUsed: '0x65682c',
+        gasUsedForL1: '0xe32b5',
+        l1BlockNumber: '0x1124343',
+        logs: [
+          {
+            address: '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            topics: [
+              '0xa9ba3ffe0b6c366b81232caab38605a0699ad5398d6cce76f91ee809e322dafc',
+            ],
+            data: '0x00000000000000000000000000000000000000000000000000016bcc41e90000',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0x0',
+            removed: false,
+          },
+          {
+            address: '0xba12222222228d8ba445958a75a0704d566bf2c8',
+            topics: [
+              '0x3c13bc30b8e878c53fd2a36b679409c073afd75950be43d8858768e956fbc20e',
+              '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd00000000000000000000049e',
+              '0x0000000000000000000000000c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            ],
+            data: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0x1',
+            removed: false,
+          },
+          {
+            address: '0xba12222222228d8ba445958a75a0704d566bf2c8',
+            topics: [
+              '0xf5847d3f2197b16cdcd2098ec95d0905cd1abdaf415f07bb7cef2bba8ac5dec4',
+              '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd00000000000000000000049e',
+            ],
+            data: '0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000c8972437a38b389ec83d1e666b69b8a4fcf8bfd0000000000000000000000005979d7b546e38e414f7e9822514be443a480052900000000000000000000000095ab45875cffdba1e5f451b950bc2e42c0053f39000000000000000000000000ec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa800000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0x2',
+            removed: false,
+          },
+          {
+            address: '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            topics: [
+              '0xa0d01593e47e69d07e0ccd87bece09411e07dd1ed40ca8f2e7af2976542a0233',
+            ],
+            data: '0x000000000000000000000000000000000000000000000000000000000016e360',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0x3',
+            removed: false,
+          },
+          {
+            address: '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            topics: [
+              '0xb77a83204ca282e08dc3a65b0a1ca32ea4e6875c38ef0bf5bf75e52a67354fac',
+              '0x0000000000000000000000000000000000000000000000000000000000000001',
+            ],
+            data: '0x0000000000000000000000000000000000000000000000000fc6fcaf272277e9',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0x4',
+            removed: false,
+          },
+          {
+            address: '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            topics: [
+              '0xdd6d1c9badb346de6925b358a472c937b41698d2632696759e43fd6527feeec4',
+              '0x0000000000000000000000000000000000000000000000000000000000000001',
+              '0x000000000000000000000000f7c5c26b574063e7b098ed74fad6779e65e3f836',
+            ],
+            data: '0x0000000000000000000000000000000000000000000000000000000000002a30',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0x5',
+            removed: false,
+          },
+          {
+            address: '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            topics: [
+              '0xb77a83204ca282e08dc3a65b0a1ca32ea4e6875c38ef0bf5bf75e52a67354fac',
+              '0x0000000000000000000000000000000000000000000000000000000000000002',
+            ],
+            data: '0x0000000000000000000000000000000000000000000000000ea23e4d3bae64a5',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0x6',
+            removed: false,
+          },
+          {
+            address: '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            topics: [
+              '0xdd6d1c9badb346de6925b358a472c937b41698d2632696759e43fd6527feeec4',
+              '0x0000000000000000000000000000000000000000000000000000000000000002',
+              '0x0000000000000000000000002237a270e87f81a30a1980422185f806e4549346',
+            ],
+            data: '0x0000000000000000000000000000000000000000000000000000000000002a30',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0x7',
+            removed: false,
+          },
+          {
+            address: '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            topics: [
+              '0xb77a83204ca282e08dc3a65b0a1ca32ea4e6875c38ef0bf5bf75e52a67354fac',
+              '0x0000000000000000000000000000000000000000000000000000000000000003',
+            ],
+            data: '0x0000000000000000000000000000000000000000000000000f016af0492eddab',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0x8',
+            removed: false,
+          },
+          {
+            address: '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            topics: [
+              '0xdd6d1c9badb346de6925b358a472c937b41698d2632696759e43fd6527feeec4',
+              '0x0000000000000000000000000000000000000000000000000000000000000003',
+              '0x000000000000000000000000a73ec45fe405b5bfcdc0bf4cbc9014bb32a01cd2',
+            ],
+            data: '0x0000000000000000000000000000000000000000000000000000000000002a30',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0x9',
+            removed: false,
+          },
+          {
+            address: '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            topics: [
+              '0x6bfb689528fa96ec1ad670ad6d6064be1ae96bfd5d2ee35c837fd0fe0c11959a',
+              '0x0000000000000000000000000000000000000000000000000000000000000002',
+            ],
+            data: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0xa',
+            removed: false,
+          },
+          {
+            address: '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            topics: [
+              '0x6bfb689528fa96ec1ad670ad6d6064be1ae96bfd5d2ee35c837fd0fe0c11959a',
+              '0x0000000000000000000000000000000000000000000000000000000000000003',
+            ],
+            data: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0xb',
+            removed: false,
+          },
+          {
+            address: '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            topics: [
+              '0x6bfb689528fa96ec1ad670ad6d6064be1ae96bfd5d2ee35c837fd0fe0c11959a',
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+            ],
+            data: '0x00000000000000000000000000000000000000000000000006f05b59d3b20000',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0xc',
+            removed: false,
+          },
+          {
+            address: '0xa8920455934da4d853faac1f94fe7bef72943ef1',
+            topics: [
+              '0x83a48fbcfc991335314e74d0496aab6a1987e992ddc85dddbcc4d6dd6ef2e9fc',
+              '0x0000000000000000000000000c8972437a38b389ec83d1e666b69b8a4fcf8bfd',
+            ],
+            data: '0x',
+            blockNumber: '0x76478aa',
+            transactionHash:
+              '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+            transactionIndex: '0x1',
+            blockHash:
+              '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+            logIndex: '0xd',
+            removed: false,
+          },
+        ],
+        logsBloom:
+          '0x04000000000000000000000040000001000080200000000000000000400000000000000000000000002000010000000000220000020000000000000440040000000400004004000000000000000000000000100000040000000000880010000080000000020000000000100000000800000000000000001008000010020000000000000000000008000000000000008000000000000400022000000000000000000000000000000004000100000000000000000402800000000100000040400040000000800000000100080040008000000000000000000000000020000060001000020004000000000000004000000000020000008000000000000000010000',
+        status: '0x1',
+        to: '0xa8920455934da4d853faac1f94fe7bef72943ef1',
+        transactionHash:
+          '0x17038640992f3fb496eb789baaacbcbc9cf913958a9599d2c0dea5f1e7a82047',
+        transactionIndex: '0x1',
+        type: '0x2',
+      },
+      blockHash:
+        '0x6d02a2aee9a2ba6e8ddec86382099c926170d40a23d5f10173e796314e38679d',
+      blockNumber: '0x76478aa',
+      timestamp: 1692753519,
+      matchReasons: [
+        {
+          type: 'event',
+          signature: 'TokensRegistered(bytes32,address[],address[])',
+          address: '0xba12222222228d8ba445958a75a0704d566bf2c8',
+          args: [
+            '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd00000000000000000000049e',
+            [
+              '0x0c8972437a38b389ec83d1E666b69b8a4fcf8bfd',
+              '0x5979D7b546E38E414F7E9822514be443A4800529',
+              '0x95aB45875cFFdba1E5f451B950bC2E42c0053f39',
+              '0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8',
+            ],
+            [
+              '0x0000000000000000000000000000000000000000',
+              '0x0000000000000000000000000000000000000000',
+              '0x0000000000000000000000000000000000000000',
+              '0x0000000000000000000000000000000000000000',
+            ],
+          ],
+          params: {
+            poolId:
+              '0x0c8972437a38b389ec83d1e666b69b8a4fcf8bfd00000000000000000000049e',
+            tokens: [
+              '0x0c8972437a38b389ec83d1E666b69b8a4fcf8bfd',
+              '0x5979D7b546E38E414F7E9822514be443A4800529',
+              '0x95aB45875cFFdba1E5f451B950bC2E42c0053f39',
+              '0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8',
+            ],
+            assetManagers: [
+              '0x0000000000000000000000000000000000000000',
+              '0x0000000000000000000000000000000000000000',
+              '0x0000000000000000000000000000000000000000',
+              '0x0000000000000000000000000000000000000000',
+            ],
+          },
+        },
+      ],
+      matchedAddresses: ['0xba12222222228d8ba445958a75a0704d566bf2c8'],
+      matchedChecksumAddresses: ['0xBA12222222228d8Ba445958a75a0704d566BF2C8'],
+      sentinel: {
+        id: '95543e2c-c080-4d68-bbe5-fa9ea402dc73',
+        name: 'Tokens Registered Arbitrum',
+        abi: [
+          {
+            inputs: [
+              {
+                internalType: 'contract IAuthorizer',
+                name: 'authorizer',
+                type: 'address',
+              },
+              { internalType: 'contract IWETH', name: 'weth', type: 'address' },
+              {
+                internalType: 'uint256',
+                name: 'pauseWindowDuration',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'bufferPeriodDuration',
+                type: 'uint256',
+              },
+            ],
+            stateMutability: 'nonpayable',
+            type: 'constructor',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'contract IAuthorizer',
+                name: 'newAuthorizer',
+                type: 'address',
+              },
+            ],
+            name: 'AuthorizerChanged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'token',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'sender',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'address',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256',
+              },
+            ],
+            name: 'ExternalBalanceTransfer',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'contract IFlashLoanRecipient',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'token',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'feeAmount',
+                type: 'uint256',
+              },
+            ],
+            name: 'FlashLoan',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'user',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'token',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'int256',
+                name: 'delta',
+                type: 'int256',
+              },
+            ],
+            name: 'InternalBalanceChanged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: false,
+                internalType: 'bool',
+                name: 'paused',
+                type: 'bool',
+              },
+            ],
+            name: 'PausedStateChanged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'liquidityProvider',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+              {
+                indexed: false,
+                internalType: 'int256[]',
+                name: 'deltas',
+                type: 'int256[]',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256[]',
+                name: 'protocolFeeAmounts',
+                type: 'uint256[]',
+              },
+            ],
+            name: 'PoolBalanceChanged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'assetManager',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'token',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'int256',
+                name: 'cashDelta',
+                type: 'int256',
+              },
+              {
+                indexed: false,
+                internalType: 'int256',
+                name: 'managedDelta',
+                type: 'int256',
+              },
+            ],
+            name: 'PoolBalanceManaged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'poolAddress',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'enum IVault.PoolSpecialization',
+                name: 'specialization',
+                type: 'uint8',
+              },
+            ],
+            name: 'PoolRegistered',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'relayer',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'sender',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'bool',
+                name: 'approved',
+                type: 'bool',
+              },
+            ],
+            name: 'RelayerApprovalChanged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'tokenIn',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'tokenOut',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'amountIn',
+                type: 'uint256',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'amountOut',
+                type: 'uint256',
+              },
+            ],
+            name: 'Swap',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: false,
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+            ],
+            name: 'TokensDeregistered',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: false,
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+              {
+                indexed: false,
+                internalType: 'address[]',
+                name: 'assetManagers',
+                type: 'address[]',
+              },
+            ],
+            name: 'TokensRegistered',
+            type: 'event',
+          },
+          {
+            inputs: [],
+            name: 'WETH',
+            outputs: [
+              { internalType: 'contract IWETH', name: '', type: 'address' },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                internalType: 'enum IVault.SwapKind',
+                name: 'kind',
+                type: 'uint8',
+              },
+              {
+                components: [
+                  { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+                  {
+                    internalType: 'uint256',
+                    name: 'assetInIndex',
+                    type: 'uint256',
+                  },
+                  {
+                    internalType: 'uint256',
+                    name: 'assetOutIndex',
+                    type: 'uint256',
+                  },
+                  { internalType: 'uint256', name: 'amount', type: 'uint256' },
+                  { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                ],
+                internalType: 'struct IVault.BatchSwapStep[]',
+                name: 'swaps',
+                type: 'tuple[]',
+              },
+              {
+                internalType: 'contract IAsset[]',
+                name: 'assets',
+                type: 'address[]',
+              },
+              {
+                components: [
+                  { internalType: 'address', name: 'sender', type: 'address' },
+                  {
+                    internalType: 'bool',
+                    name: 'fromInternalBalance',
+                    type: 'bool',
+                  },
+                  {
+                    internalType: 'address payable',
+                    name: 'recipient',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'bool',
+                    name: 'toInternalBalance',
+                    type: 'bool',
+                  },
+                ],
+                internalType: 'struct IVault.FundManagement',
+                name: 'funds',
+                type: 'tuple',
+              },
+              { internalType: 'int256[]', name: 'limits', type: 'int256[]' },
+              { internalType: 'uint256', name: 'deadline', type: 'uint256' },
+            ],
+            name: 'batchSwap',
+            outputs: [
+              {
+                internalType: 'int256[]',
+                name: 'assetDeltas',
+                type: 'int256[]',
+              },
+            ],
+            stateMutability: 'payable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+              {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+            ],
+            name: 'deregisterTokens',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+              { internalType: 'address', name: 'sender', type: 'address' },
+              {
+                internalType: 'address payable',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                components: [
+                  {
+                    internalType: 'contract IAsset[]',
+                    name: 'assets',
+                    type: 'address[]',
+                  },
+                  {
+                    internalType: 'uint256[]',
+                    name: 'minAmountsOut',
+                    type: 'uint256[]',
+                  },
+                  { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                  {
+                    internalType: 'bool',
+                    name: 'toInternalBalance',
+                    type: 'bool',
+                  },
+                ],
+                internalType: 'struct IVault.ExitPoolRequest',
+                name: 'request',
+                type: 'tuple',
+              },
+            ],
+            name: 'exitPool',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                internalType: 'contract IFlashLoanRecipient',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+              { internalType: 'uint256[]', name: 'amounts', type: 'uint256[]' },
+              { internalType: 'bytes', name: 'userData', type: 'bytes' },
+            ],
+            name: 'flashLoan',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes4', name: 'selector', type: 'bytes4' },
+            ],
+            name: 'getActionId',
+            outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [],
+            name: 'getAuthorizer',
+            outputs: [
+              {
+                internalType: 'contract IAuthorizer',
+                name: '',
+                type: 'address',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [],
+            name: 'getDomainSeparator',
+            outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'address', name: 'user', type: 'address' },
+              {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+            ],
+            name: 'getInternalBalance',
+            outputs: [
+              {
+                internalType: 'uint256[]',
+                name: 'balances',
+                type: 'uint256[]',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'address', name: 'user', type: 'address' },
+            ],
+            name: 'getNextNonce',
+            outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [],
+            name: 'getPausedState',
+            outputs: [
+              { internalType: 'bool', name: 'paused', type: 'bool' },
+              {
+                internalType: 'uint256',
+                name: 'pauseWindowEndTime',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'bufferPeriodEndTime',
+                type: 'uint256',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+            ],
+            name: 'getPool',
+            outputs: [
+              { internalType: 'address', name: '', type: 'address' },
+              {
+                internalType: 'enum IVault.PoolSpecialization',
+                name: '',
+                type: 'uint8',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+              {
+                internalType: 'contract IERC20',
+                name: 'token',
+                type: 'address',
+              },
+            ],
+            name: 'getPoolTokenInfo',
+            outputs: [
+              { internalType: 'uint256', name: 'cash', type: 'uint256' },
+              { internalType: 'uint256', name: 'managed', type: 'uint256' },
+              {
+                internalType: 'uint256',
+                name: 'lastChangeBlock',
+                type: 'uint256',
+              },
+              {
+                internalType: 'address',
+                name: 'assetManager',
+                type: 'address',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+            ],
+            name: 'getPoolTokens',
+            outputs: [
+              {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+              {
+                internalType: 'uint256[]',
+                name: 'balances',
+                type: 'uint256[]',
+              },
+              {
+                internalType: 'uint256',
+                name: 'lastChangeBlock',
+                type: 'uint256',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [],
+            name: 'getProtocolFeesCollector',
+            outputs: [
+              {
+                internalType: 'contract ProtocolFeesCollector',
+                name: '',
+                type: 'address',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'address', name: 'user', type: 'address' },
+              { internalType: 'address', name: 'relayer', type: 'address' },
+            ],
+            name: 'hasApprovedRelayer',
+            outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+              { internalType: 'address', name: 'sender', type: 'address' },
+              { internalType: 'address', name: 'recipient', type: 'address' },
+              {
+                components: [
+                  {
+                    internalType: 'contract IAsset[]',
+                    name: 'assets',
+                    type: 'address[]',
+                  },
+                  {
+                    internalType: 'uint256[]',
+                    name: 'maxAmountsIn',
+                    type: 'uint256[]',
+                  },
+                  { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                  {
+                    internalType: 'bool',
+                    name: 'fromInternalBalance',
+                    type: 'bool',
+                  },
+                ],
+                internalType: 'struct IVault.JoinPoolRequest',
+                name: 'request',
+                type: 'tuple',
+              },
+            ],
+            name: 'joinPool',
+            outputs: [],
+            stateMutability: 'payable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                components: [
+                  {
+                    internalType: 'enum IVault.PoolBalanceOpKind',
+                    name: 'kind',
+                    type: 'uint8',
+                  },
+                  { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+                  {
+                    internalType: 'contract IERC20',
+                    name: 'token',
+                    type: 'address',
+                  },
+                  { internalType: 'uint256', name: 'amount', type: 'uint256' },
+                ],
+                internalType: 'struct IVault.PoolBalanceOp[]',
+                name: 'ops',
+                type: 'tuple[]',
+              },
+            ],
+            name: 'managePoolBalance',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                components: [
+                  {
+                    internalType: 'enum IVault.UserBalanceOpKind',
+                    name: 'kind',
+                    type: 'uint8',
+                  },
+                  {
+                    internalType: 'contract IAsset',
+                    name: 'asset',
+                    type: 'address',
+                  },
+                  { internalType: 'uint256', name: 'amount', type: 'uint256' },
+                  { internalType: 'address', name: 'sender', type: 'address' },
+                  {
+                    internalType: 'address payable',
+                    name: 'recipient',
+                    type: 'address',
+                  },
+                ],
+                internalType: 'struct IVault.UserBalanceOp[]',
+                name: 'ops',
+                type: 'tuple[]',
+              },
+            ],
+            name: 'manageUserBalance',
+            outputs: [],
+            stateMutability: 'payable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                internalType: 'enum IVault.SwapKind',
+                name: 'kind',
+                type: 'uint8',
+              },
+              {
+                components: [
+                  { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+                  {
+                    internalType: 'uint256',
+                    name: 'assetInIndex',
+                    type: 'uint256',
+                  },
+                  {
+                    internalType: 'uint256',
+                    name: 'assetOutIndex',
+                    type: 'uint256',
+                  },
+                  { internalType: 'uint256', name: 'amount', type: 'uint256' },
+                  { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                ],
+                internalType: 'struct IVault.BatchSwapStep[]',
+                name: 'swaps',
+                type: 'tuple[]',
+              },
+              {
+                internalType: 'contract IAsset[]',
+                name: 'assets',
+                type: 'address[]',
+              },
+              {
+                components: [
+                  { internalType: 'address', name: 'sender', type: 'address' },
+                  {
+                    internalType: 'bool',
+                    name: 'fromInternalBalance',
+                    type: 'bool',
+                  },
+                  {
+                    internalType: 'address payable',
+                    name: 'recipient',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'bool',
+                    name: 'toInternalBalance',
+                    type: 'bool',
+                  },
+                ],
+                internalType: 'struct IVault.FundManagement',
+                name: 'funds',
+                type: 'tuple',
+              },
+            ],
+            name: 'queryBatchSwap',
+            outputs: [{ internalType: 'int256[]', name: '', type: 'int256[]' }],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                internalType: 'enum IVault.PoolSpecialization',
+                name: 'specialization',
+                type: 'uint8',
+              },
+            ],
+            name: 'registerPool',
+            outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+              {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+              {
+                internalType: 'address[]',
+                name: 'assetManagers',
+                type: 'address[]',
+              },
+            ],
+            name: 'registerTokens',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                internalType: 'contract IAuthorizer',
+                name: 'newAuthorizer',
+                type: 'address',
+              },
+            ],
+            name: 'setAuthorizer',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [{ internalType: 'bool', name: 'paused', type: 'bool' }],
+            name: 'setPaused',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'address', name: 'sender', type: 'address' },
+              { internalType: 'address', name: 'relayer', type: 'address' },
+              { internalType: 'bool', name: 'approved', type: 'bool' },
+            ],
+            name: 'setRelayerApproval',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                components: [
+                  { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+                  {
+                    internalType: 'enum IVault.SwapKind',
+                    name: 'kind',
+                    type: 'uint8',
+                  },
+                  {
+                    internalType: 'contract IAsset',
+                    name: 'assetIn',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'contract IAsset',
+                    name: 'assetOut',
+                    type: 'address',
+                  },
+                  { internalType: 'uint256', name: 'amount', type: 'uint256' },
+                  { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                ],
+                internalType: 'struct IVault.SingleSwap',
+                name: 'singleSwap',
+                type: 'tuple',
+              },
+              {
+                components: [
+                  { internalType: 'address', name: 'sender', type: 'address' },
+                  {
+                    internalType: 'bool',
+                    name: 'fromInternalBalance',
+                    type: 'bool',
+                  },
+                  {
+                    internalType: 'address payable',
+                    name: 'recipient',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'bool',
+                    name: 'toInternalBalance',
+                    type: 'bool',
+                  },
+                ],
+                internalType: 'struct IVault.FundManagement',
+                name: 'funds',
+                type: 'tuple',
+              },
+              { internalType: 'uint256', name: 'limit', type: 'uint256' },
+              { internalType: 'uint256', name: 'deadline', type: 'uint256' },
+            ],
+            name: 'swap',
+            outputs: [
+              {
+                internalType: 'uint256',
+                name: 'amountCalculated',
+                type: 'uint256',
+              },
+            ],
+            stateMutability: 'payable',
+            type: 'function',
+          },
+          { stateMutability: 'payable', type: 'receive' },
+        ],
+        addresses: ['0xBA12222222228d8Ba445958a75a0704d566BF2C8'],
+        confirmBlocks: 1,
+        network: 'arbitrum',
+        chainId: 42161,
+      },
+      type: 'BLOCK',
+      value: '0x0',
+    },
+  ],
+};
+
+export default defenderEventBody;

--- a/tests/mocks/defender-event-body-ethereum.ts
+++ b/tests/mocks/defender-event-body-ethereum.ts
@@ -1,0 +1,1363 @@
+import { DefenderBody } from '@/modules/defender';
+
+const body: DefenderBody = {
+  events: [
+    {
+      hash: '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+      transaction: {
+        transactionHash:
+          '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+        blockHash:
+          '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+        blockNumber: '0x1123ba6',
+        logs: [
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0x8929e9dbd2785e3ba16175e596cdd61520fee0d1',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x0000000000000000000000000000000000000000000422ca8b0a00a425000000',
+            logIndex: '0x1e2',
+            removed: false,
+            topics: [
+              '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+              '0x000000000000000000000000ce1a75b8964ef5ec7893f98df1c379557a0c97b7',
+              '0x00000000000000000000000067e0524739e59ca57ac27e520ea05d14cdb6015e',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0x8929e9dbd2785e3ba16175e596cdd61520fee0d1',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x0000000000000000000000000000000000000000000000056bc75e2d62c3b4c0',
+            logIndex: '0x1e3',
+            removed: false,
+            topics: [
+              '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925',
+              '0x000000000000000000000000ce1a75b8964ef5ec7893f98df1c379557a0c97b7',
+              '0x00000000000000000000000067e0524739e59ca57ac27e520ea05d14cdb6015e',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x000000000000000000000000000000000000000000000000000000071ab17fd6',
+            logIndex: '0x1e4',
+            removed: false,
+            topics: [
+              '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+              '0x000000000000000000000000ce1a75b8964ef5ec7893f98df1c379557a0c97b7',
+              '0x00000000000000000000000067e0524739e59ca57ac27e520ea05d14cdb6015e',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0x8929e9dbd2785e3ba16175e596cdd61520fee0d1',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x0000000000000000000000000000000000000000000422ca8b0a00a425000000',
+            logIndex: '0x1e5',
+            removed: false,
+            topics: [
+              '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925',
+              '0x00000000000000000000000067e0524739e59ca57ac27e520ea05d14cdb6015e',
+              '0x000000000000000000000000ba12222222228d8ba445958a75a0704d566bf2c8',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x000000000000000000000000000000000000000000000000000000071ab17fd6',
+            logIndex: '0x1e6',
+            removed: false,
+            topics: [
+              '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925',
+              '0x00000000000000000000000067e0524739e59ca57ac27e520ea05d14cdb6015e',
+              '0x000000000000000000000000ba12222222228d8ba445958a75a0704d566bf2c8',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb6',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x00000000000000000000000000000000000000000000000000470de4df820000',
+            logIndex: '0x1e7',
+            removed: false,
+            topics: [
+              '0xa9ba3ffe0b6c366b81232caab38605a0699ad5398d6cce76f91ee809e322dafc',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xba12222222228d8ba445958a75a0704d566bf2c8',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x0000000000000000000000000000000000000000000000000000000000000002',
+            logIndex: '0x1e8',
+            removed: false,
+            topics: [
+              '0x3c13bc30b8e878c53fd2a36b679409c073afd75950be43d8858768e956fbc20e',
+              '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb60002000000000000000005d7',
+              '0x000000000000000000000000c0d9c93759399ddb7310f68f6d007ba8c55c8cb6',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xba12222222228d8ba445958a75a0704d566bf2c8',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000020000000000000000000000008929e9dbd2785e3ba16175e596cdd61520fee0d1000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+            logIndex: '0x1e9',
+            removed: false,
+            topics: [
+              '0xf5847d3f2197b16cdcd2098ec95d0905cd1abdaf415f07bb7cef2bba8ac5dec4',
+              '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb60002000000000000000005d7',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb6',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x0000000000000000000000000000000000000000000000000000000064e502a30000000000000000000000000000000000000000000000000000000064e502a3000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000dbd2fc137a30000000000000000000000000000000000000000000000000000002386f26fc1000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000dbd2fc137a30000000000000000000000000000000000000000000000000000002386f26fc10000',
+            logIndex: '0x1ea',
+            removed: false,
+            topics: [
+              '0x0f3631f9dab08169d1db21c6dc5f32536fb2b0a6b9bb5330d71c52132f968be0',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb6',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            logIndex: '0x1eb',
+            removed: false,
+            topics: [
+              '0x5a9e84f78f7957cb4ed7478eb0fcad35ee4ecbe2e0f298420b28a3955392573f',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0x0f3e0c4218b7b0108a3643cfe9d3ec0d4f57c54e',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x',
+            logIndex: '0x1ec',
+            removed: false,
+            topics: [
+              '0x83a48fbcfc991335314e74d0496aab6a1987e992ddc85dddbcc4d6dd6ef2e9fc',
+              '0x000000000000000000000000c0d9c93759399ddb7310f68f6d007ba8c55c8cb6',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0x67e0524739e59ca57ac27e520ea05d14cdb6015e',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb60002000000000000000005d70000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000001a0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000470de4df82000000000000000000000000000067e0524739e59ca57ac27e520ea05d14cdb6015e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016414c544420466a6f726420466f756e647279204c4250000000000000000000000000000000000000000000000000000000000000000000000000000000000008414c54445f4c425000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000008929e9dbd2785e3ba16175e596cdd61520fee0d1000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4800000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000dbd2fc137a30000000000000000000000000000000000000000000000000000002386f26fc10000',
+            logIndex: '0x1ed',
+            removed: false,
+            topics: [
+              '0x6c130008702156f386ee27059c11c20c3cdb9a490913562797da16d51928835d',
+              '0x000000000000000000000000c0d9c93759399ddb7310f68f6d007ba8c55c8cb6',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb6',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x00000000000000000000000000000000000000000000000000000000000f4240',
+            logIndex: '0x1ee',
+            removed: false,
+            topics: [
+              '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb6',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x00000000000000000000000000000000000000000007dcaf2f15eb5b90024a50',
+            logIndex: '0x1ef',
+            removed: false,
+            topics: [
+              '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+              '0x0000000000000000000000000000000000000000000000000000000000000000',
+              '0x00000000000000000000000067e0524739e59ca57ac27e520ea05d14cdb6015e',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0x8929e9dbd2785e3ba16175e596cdd61520fee0d1',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x0000000000000000000000000000000000000000000422ca8b0a00a425000000',
+            logIndex: '0x1f0',
+            removed: false,
+            topics: [
+              '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+              '0x00000000000000000000000067e0524739e59ca57ac27e520ea05d14cdb6015e',
+              '0x000000000000000000000000ba12222222228d8ba445958a75a0704d566bf2c8',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0x8929e9dbd2785e3ba16175e596cdd61520fee0d1',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            logIndex: '0x1f1',
+            removed: false,
+            topics: [
+              '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925',
+              '0x00000000000000000000000067e0524739e59ca57ac27e520ea05d14cdb6015e',
+              '0x000000000000000000000000ba12222222228d8ba445958a75a0704d566bf2c8',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x000000000000000000000000000000000000000000000000000000071ab17fd6',
+            logIndex: '0x1f2',
+            removed: false,
+            topics: [
+              '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+              '0x00000000000000000000000067e0524739e59ca57ac27e520ea05d14cdb6015e',
+              '0x000000000000000000000000ba12222222228d8ba445958a75a0704d566bf2c8',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xba12222222228d8ba445958a75a0704d566bf2c8',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000000020000000000000000000000008929e9dbd2785e3ba16175e596cdd61520fee0d1000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4800000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000422ca8b0a00a425000000000000000000000000000000000000000000000000000000000000071ab17fd6000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+            logIndex: '0x1f3',
+            removed: false,
+            topics: [
+              '0xe5ce249087ce04f05a957192435400fd97868dba0e6a4b4c049abf8af80dae78',
+              '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb60002000000000000000005d7',
+              '0x00000000000000000000000067e0524739e59ca57ac27e520ea05d14cdb6015e',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0x67e0524739e59ca57ac27e520ea05d14cdb6015e',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000000020000000000000000000000008929e9dbd2785e3ba16175e596cdd61520fee0d1000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4800000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000422ca8b0a00a425000000000000000000000000000000000000000000000000000000000000071ab17fd600000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000422ca8b0a00a425000000000000000000000000000000000000000000000000000000000000071ab17fd6',
+            logIndex: '0x1f4',
+            removed: false,
+            topics: [
+              '0x5dcdc6c8b7b09c26d0c867e99f2b7389b69d982aa8f10b1373f84667a8f58b35',
+              '0x000000000000000000000000c0d9c93759399ddb7310f68f6d007ba8c55c8cb6',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb6',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x0000000000000000000000000000000000000000000000000000000064e5f4c00000000000000000000000000000000000000000000000000000000064e9e940000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000dbd349cafa3bf6400000000000000000000000000000000000000000000000000238ff7bc54ac95000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000009b6e64a8ec600000000000000000000000000000000000000000000000000000429d069189e0000',
+            logIndex: '0x1f5',
+            removed: false,
+            topics: [
+              '0x0f3631f9dab08169d1db21c6dc5f32536fb2b0a6b9bb5330d71c52132f968be0',
+            ],
+            transactionIndex: '0xe7',
+          },
+          {
+            transactionHash:
+              '0x84d5fb765f934f6ca03aab3c594e2ee03b4add00064cb83e69bb8723e0cd299b',
+            address: '0x67e0524739e59ca57ac27e520ea05d14cdb6015e',
+            blockHash:
+              '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+            blockNumber: '0x1123ba6',
+            data: '0x0000000000000000000000000000000000000000000000000000000064e5f4c00000000000000000000000000000000000000000000000000000000064e9e9400000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000009b6e64a8ec600000000000000000000000000000000000000000000000000000429d069189e0000',
+            logIndex: '0x1f6',
+            removed: false,
+            topics: [
+              '0x5b604c3eb0508fc702242270d353c7673f02b609e03862e244766785e39c278c',
+              '0x000000000000000000000000c0d9c93759399ddb7310f68f6d007ba8c55c8cb6',
+            ],
+            transactionIndex: '0xe7',
+          },
+        ],
+        contractAddress: null,
+        effectiveGasPrice: '0x72573b721',
+        cumulativeGasUsed: '0x14509ab',
+        from: '0xce1a75b8964ef5ec7893f98df1c379557a0c97b7',
+        gasUsed: '0x498f86',
+        logsBloom:
+          '0x04040000000000000000002000200000000000010000000800000000000000000000000008000000000000010000008000920002000000000000000400200000000000004000000008000048000020000000000000000000000001280800000000000000020000000002100000000808000000000000000000000010020400000000100000000800000000000000002000000000010000022808000900000000020000000000202000000001000000000000204002c00000000100000000000040000002802080000100000000080000002000000000000000000000001020060010000000000000000000004000000000030000000001000000000000010000',
+        status: '0x1',
+        to: '0x67e0524739e59ca57ac27e520ea05d14cdb6015e',
+        transactionIndex: '0xe7',
+        type: '0x2',
+      },
+      blockHash:
+        '0xb392bee4fa2af31ec2a8e521f5383086b1fecceb8072df505350008f27ad7a08',
+      blockNumber: '0x1123ba6',
+      timestamp: 1692730019,
+      matchReasons: [
+        {
+          type: 'event',
+          signature: 'TokensRegistered(bytes32,address[],address[])',
+          address: '0xba12222222228d8ba445958a75a0704d566bf2c8',
+          args: [
+            '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb60002000000000000000005d7',
+            [
+              '0x8929e9DbD2785e3BA16175E596CDD61520feE0D1',
+              '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+            ],
+            [
+              '0x0000000000000000000000000000000000000000',
+              '0x0000000000000000000000000000000000000000',
+            ],
+          ],
+          params: {
+            poolId:
+              '0xc0d9c93759399ddb7310f68f6d007ba8c55c8cb60002000000000000000005d7',
+            tokens: [
+              '0x8929e9DbD2785e3BA16175E596CDD61520feE0D1',
+              '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+            ],
+            assetManagers: [
+              '0x0000000000000000000000000000000000000000',
+              '0x0000000000000000000000000000000000000000',
+            ],
+          },
+        },
+      ],
+      matchedAddresses: ['0xba12222222228d8ba445958a75a0704d566bf2c8'],
+      matchedChecksumAddresses: ['0xBA12222222228d8Ba445958a75a0704d566BF2C8'],
+      sentinel: {
+        id: 'd455b097-0b3c-4aa1-b499-e93e2ece450c',
+        name: 'TokensRegistered',
+        abi: [
+          {
+            inputs: [
+              {
+                internalType: 'contract IAuthorizer',
+                name: 'authorizer',
+                type: 'address',
+              },
+              { internalType: 'contract IWETH', name: 'weth', type: 'address' },
+              {
+                internalType: 'uint256',
+                name: 'pauseWindowDuration',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'bufferPeriodDuration',
+                type: 'uint256',
+              },
+            ],
+            stateMutability: 'nonpayable',
+            type: 'constructor',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'contract IAuthorizer',
+                name: 'newAuthorizer',
+                type: 'address',
+              },
+            ],
+            name: 'AuthorizerChanged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'token',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'sender',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'address',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256',
+              },
+            ],
+            name: 'ExternalBalanceTransfer',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'contract IFlashLoanRecipient',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'token',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'amount',
+                type: 'uint256',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'feeAmount',
+                type: 'uint256',
+              },
+            ],
+            name: 'FlashLoan',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'user',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'token',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'int256',
+                name: 'delta',
+                type: 'int256',
+              },
+            ],
+            name: 'InternalBalanceChanged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: false,
+                internalType: 'bool',
+                name: 'paused',
+                type: 'bool',
+              },
+            ],
+            name: 'PausedStateChanged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'liquidityProvider',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+              {
+                indexed: false,
+                internalType: 'int256[]',
+                name: 'deltas',
+                type: 'int256[]',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256[]',
+                name: 'protocolFeeAmounts',
+                type: 'uint256[]',
+              },
+            ],
+            name: 'PoolBalanceChanged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'assetManager',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'token',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'int256',
+                name: 'cashDelta',
+                type: 'int256',
+              },
+              {
+                indexed: false,
+                internalType: 'int256',
+                name: 'managedDelta',
+                type: 'int256',
+              },
+            ],
+            name: 'PoolBalanceManaged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'poolAddress',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'enum IVault.PoolSpecialization',
+                name: 'specialization',
+                type: 'uint8',
+              },
+            ],
+            name: 'PoolRegistered',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'relayer',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'address',
+                name: 'sender',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'bool',
+                name: 'approved',
+                type: 'bool',
+              },
+            ],
+            name: 'RelayerApprovalChanged',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'tokenIn',
+                type: 'address',
+              },
+              {
+                indexed: true,
+                internalType: 'contract IERC20',
+                name: 'tokenOut',
+                type: 'address',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'amountIn',
+                type: 'uint256',
+              },
+              {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'amountOut',
+                type: 'uint256',
+              },
+            ],
+            name: 'Swap',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: false,
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+            ],
+            name: 'TokensDeregistered',
+            type: 'event',
+          },
+          {
+            anonymous: false,
+            inputs: [
+              {
+                indexed: true,
+                internalType: 'bytes32',
+                name: 'poolId',
+                type: 'bytes32',
+              },
+              {
+                indexed: false,
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+              {
+                indexed: false,
+                internalType: 'address[]',
+                name: 'assetManagers',
+                type: 'address[]',
+              },
+            ],
+            name: 'TokensRegistered',
+            type: 'event',
+          },
+          {
+            inputs: [],
+            name: 'WETH',
+            outputs: [
+              { internalType: 'contract IWETH', name: '', type: 'address' },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                internalType: 'enum IVault.SwapKind',
+                name: 'kind',
+                type: 'uint8',
+              },
+              {
+                components: [
+                  { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+                  {
+                    internalType: 'uint256',
+                    name: 'assetInIndex',
+                    type: 'uint256',
+                  },
+                  {
+                    internalType: 'uint256',
+                    name: 'assetOutIndex',
+                    type: 'uint256',
+                  },
+                  { internalType: 'uint256', name: 'amount', type: 'uint256' },
+                  { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                ],
+                internalType: 'struct IVault.BatchSwapStep[]',
+                name: 'swaps',
+                type: 'tuple[]',
+              },
+              {
+                internalType: 'contract IAsset[]',
+                name: 'assets',
+                type: 'address[]',
+              },
+              {
+                components: [
+                  { internalType: 'address', name: 'sender', type: 'address' },
+                  {
+                    internalType: 'bool',
+                    name: 'fromInternalBalance',
+                    type: 'bool',
+                  },
+                  {
+                    internalType: 'address payable',
+                    name: 'recipient',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'bool',
+                    name: 'toInternalBalance',
+                    type: 'bool',
+                  },
+                ],
+                internalType: 'struct IVault.FundManagement',
+                name: 'funds',
+                type: 'tuple',
+              },
+              { internalType: 'int256[]', name: 'limits', type: 'int256[]' },
+              { internalType: 'uint256', name: 'deadline', type: 'uint256' },
+            ],
+            name: 'batchSwap',
+            outputs: [
+              {
+                internalType: 'int256[]',
+                name: 'assetDeltas',
+                type: 'int256[]',
+              },
+            ],
+            stateMutability: 'payable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+              {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+            ],
+            name: 'deregisterTokens',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+              { internalType: 'address', name: 'sender', type: 'address' },
+              {
+                internalType: 'address payable',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                components: [
+                  {
+                    internalType: 'contract IAsset[]',
+                    name: 'assets',
+                    type: 'address[]',
+                  },
+                  {
+                    internalType: 'uint256[]',
+                    name: 'minAmountsOut',
+                    type: 'uint256[]',
+                  },
+                  { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                  {
+                    internalType: 'bool',
+                    name: 'toInternalBalance',
+                    type: 'bool',
+                  },
+                ],
+                internalType: 'struct IVault.ExitPoolRequest',
+                name: 'request',
+                type: 'tuple',
+              },
+            ],
+            name: 'exitPool',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                internalType: 'contract IFlashLoanRecipient',
+                name: 'recipient',
+                type: 'address',
+              },
+              {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+              { internalType: 'uint256[]', name: 'amounts', type: 'uint256[]' },
+              { internalType: 'bytes', name: 'userData', type: 'bytes' },
+            ],
+            name: 'flashLoan',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes4', name: 'selector', type: 'bytes4' },
+            ],
+            name: 'getActionId',
+            outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [],
+            name: 'getAuthorizer',
+            outputs: [
+              {
+                internalType: 'contract IAuthorizer',
+                name: '',
+                type: 'address',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [],
+            name: 'getDomainSeparator',
+            outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'address', name: 'user', type: 'address' },
+              {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+            ],
+            name: 'getInternalBalance',
+            outputs: [
+              {
+                internalType: 'uint256[]',
+                name: 'balances',
+                type: 'uint256[]',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'address', name: 'user', type: 'address' },
+            ],
+            name: 'getNextNonce',
+            outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [],
+            name: 'getPausedState',
+            outputs: [
+              { internalType: 'bool', name: 'paused', type: 'bool' },
+              {
+                internalType: 'uint256',
+                name: 'pauseWindowEndTime',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'bufferPeriodEndTime',
+                type: 'uint256',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+            ],
+            name: 'getPool',
+            outputs: [
+              { internalType: 'address', name: '', type: 'address' },
+              {
+                internalType: 'enum IVault.PoolSpecialization',
+                name: '',
+                type: 'uint8',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+              {
+                internalType: 'contract IERC20',
+                name: 'token',
+                type: 'address',
+              },
+            ],
+            name: 'getPoolTokenInfo',
+            outputs: [
+              { internalType: 'uint256', name: 'cash', type: 'uint256' },
+              { internalType: 'uint256', name: 'managed', type: 'uint256' },
+              {
+                internalType: 'uint256',
+                name: 'lastChangeBlock',
+                type: 'uint256',
+              },
+              {
+                internalType: 'address',
+                name: 'assetManager',
+                type: 'address',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+            ],
+            name: 'getPoolTokens',
+            outputs: [
+              {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+              {
+                internalType: 'uint256[]',
+                name: 'balances',
+                type: 'uint256[]',
+              },
+              {
+                internalType: 'uint256',
+                name: 'lastChangeBlock',
+                type: 'uint256',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [],
+            name: 'getProtocolFeesCollector',
+            outputs: [
+              {
+                internalType: 'contract ProtocolFeesCollector',
+                name: '',
+                type: 'address',
+              },
+            ],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'address', name: 'user', type: 'address' },
+              { internalType: 'address', name: 'relayer', type: 'address' },
+            ],
+            name: 'hasApprovedRelayer',
+            outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+            stateMutability: 'view',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+              { internalType: 'address', name: 'sender', type: 'address' },
+              { internalType: 'address', name: 'recipient', type: 'address' },
+              {
+                components: [
+                  {
+                    internalType: 'contract IAsset[]',
+                    name: 'assets',
+                    type: 'address[]',
+                  },
+                  {
+                    internalType: 'uint256[]',
+                    name: 'maxAmountsIn',
+                    type: 'uint256[]',
+                  },
+                  { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                  {
+                    internalType: 'bool',
+                    name: 'fromInternalBalance',
+                    type: 'bool',
+                  },
+                ],
+                internalType: 'struct IVault.JoinPoolRequest',
+                name: 'request',
+                type: 'tuple',
+              },
+            ],
+            name: 'joinPool',
+            outputs: [],
+            stateMutability: 'payable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                components: [
+                  {
+                    internalType: 'enum IVault.PoolBalanceOpKind',
+                    name: 'kind',
+                    type: 'uint8',
+                  },
+                  { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+                  {
+                    internalType: 'contract IERC20',
+                    name: 'token',
+                    type: 'address',
+                  },
+                  { internalType: 'uint256', name: 'amount', type: 'uint256' },
+                ],
+                internalType: 'struct IVault.PoolBalanceOp[]',
+                name: 'ops',
+                type: 'tuple[]',
+              },
+            ],
+            name: 'managePoolBalance',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                components: [
+                  {
+                    internalType: 'enum IVault.UserBalanceOpKind',
+                    name: 'kind',
+                    type: 'uint8',
+                  },
+                  {
+                    internalType: 'contract IAsset',
+                    name: 'asset',
+                    type: 'address',
+                  },
+                  { internalType: 'uint256', name: 'amount', type: 'uint256' },
+                  { internalType: 'address', name: 'sender', type: 'address' },
+                  {
+                    internalType: 'address payable',
+                    name: 'recipient',
+                    type: 'address',
+                  },
+                ],
+                internalType: 'struct IVault.UserBalanceOp[]',
+                name: 'ops',
+                type: 'tuple[]',
+              },
+            ],
+            name: 'manageUserBalance',
+            outputs: [],
+            stateMutability: 'payable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                internalType: 'enum IVault.SwapKind',
+                name: 'kind',
+                type: 'uint8',
+              },
+              {
+                components: [
+                  { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+                  {
+                    internalType: 'uint256',
+                    name: 'assetInIndex',
+                    type: 'uint256',
+                  },
+                  {
+                    internalType: 'uint256',
+                    name: 'assetOutIndex',
+                    type: 'uint256',
+                  },
+                  { internalType: 'uint256', name: 'amount', type: 'uint256' },
+                  { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                ],
+                internalType: 'struct IVault.BatchSwapStep[]',
+                name: 'swaps',
+                type: 'tuple[]',
+              },
+              {
+                internalType: 'contract IAsset[]',
+                name: 'assets',
+                type: 'address[]',
+              },
+              {
+                components: [
+                  { internalType: 'address', name: 'sender', type: 'address' },
+                  {
+                    internalType: 'bool',
+                    name: 'fromInternalBalance',
+                    type: 'bool',
+                  },
+                  {
+                    internalType: 'address payable',
+                    name: 'recipient',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'bool',
+                    name: 'toInternalBalance',
+                    type: 'bool',
+                  },
+                ],
+                internalType: 'struct IVault.FundManagement',
+                name: 'funds',
+                type: 'tuple',
+              },
+            ],
+            name: 'queryBatchSwap',
+            outputs: [{ internalType: 'int256[]', name: '', type: 'int256[]' }],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                internalType: 'enum IVault.PoolSpecialization',
+                name: 'specialization',
+                type: 'uint8',
+              },
+            ],
+            name: 'registerPool',
+            outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+              {
+                internalType: 'contract IERC20[]',
+                name: 'tokens',
+                type: 'address[]',
+              },
+              {
+                internalType: 'address[]',
+                name: 'assetManagers',
+                type: 'address[]',
+              },
+            ],
+            name: 'registerTokens',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                internalType: 'contract IAuthorizer',
+                name: 'newAuthorizer',
+                type: 'address',
+              },
+            ],
+            name: 'setAuthorizer',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [{ internalType: 'bool', name: 'paused', type: 'bool' }],
+            name: 'setPaused',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              { internalType: 'address', name: 'sender', type: 'address' },
+              { internalType: 'address', name: 'relayer', type: 'address' },
+              { internalType: 'bool', name: 'approved', type: 'bool' },
+            ],
+            name: 'setRelayerApproval',
+            outputs: [],
+            stateMutability: 'nonpayable',
+            type: 'function',
+          },
+          {
+            inputs: [
+              {
+                components: [
+                  { internalType: 'bytes32', name: 'poolId', type: 'bytes32' },
+                  {
+                    internalType: 'enum IVault.SwapKind',
+                    name: 'kind',
+                    type: 'uint8',
+                  },
+                  {
+                    internalType: 'contract IAsset',
+                    name: 'assetIn',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'contract IAsset',
+                    name: 'assetOut',
+                    type: 'address',
+                  },
+                  { internalType: 'uint256', name: 'amount', type: 'uint256' },
+                  { internalType: 'bytes', name: 'userData', type: 'bytes' },
+                ],
+                internalType: 'struct IVault.SingleSwap',
+                name: 'singleSwap',
+                type: 'tuple',
+              },
+              {
+                components: [
+                  { internalType: 'address', name: 'sender', type: 'address' },
+                  {
+                    internalType: 'bool',
+                    name: 'fromInternalBalance',
+                    type: 'bool',
+                  },
+                  {
+                    internalType: 'address payable',
+                    name: 'recipient',
+                    type: 'address',
+                  },
+                  {
+                    internalType: 'bool',
+                    name: 'toInternalBalance',
+                    type: 'bool',
+                  },
+                ],
+                internalType: 'struct IVault.FundManagement',
+                name: 'funds',
+                type: 'tuple',
+              },
+              { internalType: 'uint256', name: 'limit', type: 'uint256' },
+              { internalType: 'uint256', name: 'deadline', type: 'uint256' },
+            ],
+            name: 'swap',
+            outputs: [
+              {
+                internalType: 'uint256',
+                name: 'amountCalculated',
+                type: 'uint256',
+              },
+            ],
+            stateMutability: 'payable',
+            type: 'function',
+          },
+          { stateMutability: 'payable', type: 'receive' },
+        ],
+        addresses: ['0xBA12222222228d8Ba445958a75a0704d566BF2C8'],
+        confirmBlocks: 1,
+        network: 'mainnet',
+        chainId: 1,
+      },
+      type: 'BLOCK',
+      value: '0x0',
+    },
+  ],
+};
+
+export default body;


### PR DESCRIPTION
Adding a new webhook that listens to events from Openzepplin Defender instead of Hal because it supports more chains. 

Has tests that use real event data I've collected. 