### PR TITLE
Use network name 'gnosis' for tokenlist allowlist

### DIFF
--- a/src/modules/allowlist/token.ts
+++ b/src/modules/allowlist/token.ts
@@ -35,6 +35,9 @@ export async function allowlistToken(chainId: number, address: string) {
   if (network === 'mainnet') {
     network = 'ethereum';
   }
+  if (network === 'gnosis-chain') {
+    network = 'gnosis';
+  }
 
   const webhookData = {
     event_type: 'allowlist_token',


### PR DESCRIPTION
In the tokenlist repo the gnosis network is just 'gnosis' so the allowlist job is failing. E.g. https://github.com/balancer/tokenlists/actions/runs/5963713285/job/16177444189