### PR TITLE
fix: price fetching

### DIFF
--- a/src/modules/prices/beets-price-fetcher.ts
+++ b/src/modules/prices/beets-price-fetcher.ts
@@ -38,7 +38,15 @@ class BeetsPriceFetcher {
     if (unspupportedChains.includes(chainId)) {
       return {};
     }
-    const gqlChain = configs[chainId].GqlChain || 'MAINNET';
+
+    let gqlChain = 'MAINNET';
+    try {
+      gqlChain = configs[chainId].GqlChain;
+    } catch (e) {
+      console.error(`Chain ${chainId} not supported`);
+      return {};
+    }
+
     const payload = JSON.stringify({
       query: `query { tokenGetCurrentPrices(chains: [${gqlChain}]) { address price }}`,
     });


### PR DESCRIPTION
Fetching prices throws:

```
TypeError
Cannot read property 'GqlChain' of undefined
```

on:
```
async fetchFromBeetsAPI(chainId) {
    const unspupportedChains = [5, 11155111];
    if (unspupportedChains.includes(chainId)) {
      return {};
    }
    const gqlChain = config_default[chainId].GqlChain || "MAINNET";
```